### PR TITLE
Rename classes

### DIFF
--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/character/JXMCharacter.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/character/JXMCharacter.java
@@ -10,7 +10,7 @@ import java.util.Objects;
  *
  * @author maeda6uiui
  */
-public class Character {
+public class JXMCharacter {
     public CharacterTextureType texture;
     public CharacterModelType model;
     public int hp;
@@ -21,7 +21,7 @@ public class Character {
     /**
      * Creates a character.
      */
-    public Character() {
+    public JXMCharacter() {
         texture = CharacterTextureType.SOLDIER_BLACK;
         model = CharacterModelType.MALE;
         hp = 100;
@@ -35,7 +35,7 @@ public class Character {
      *
      * @param character Character
      */
-    public Character(Character character) {
+    public JXMCharacter(JXMCharacter character) {
         this.texture = character.texture;
         this.model = character.model;
         this.hp = character.hp;
@@ -54,7 +54,7 @@ public class Character {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        Character character = (Character) o;
+        JXMCharacter character = (JXMCharacter) o;
         return hp == character.hp
                 && texture == character.texture
                 && model == character.model
@@ -68,32 +68,32 @@ public class Character {
         return Objects.hash(texture, model, hp, aiLevel, weapons, type);
     }
 
-    public Character setTexture(CharacterTextureType texture) {
+    public JXMCharacter setTexture(CharacterTextureType texture) {
         this.texture = texture;
         return this;
     }
 
-    public Character setModel(CharacterModelType model) {
+    public JXMCharacter setModel(CharacterModelType model) {
         this.model = model;
         return this;
     }
 
-    public Character setHp(int hp) {
+    public JXMCharacter setHp(int hp) {
         this.hp = hp;
         return this;
     }
 
-    public Character setAiLevel(AILevel aiLevel) {
+    public JXMCharacter setAiLevel(AILevel aiLevel) {
         this.aiLevel = aiLevel;
         return this;
     }
 
-    public Character setWeapons(List<Integer> weapons) {
+    public JXMCharacter setWeapons(List<Integer> weapons) {
         this.weapons = weapons;
         return this;
     }
 
-    public Character setType(CharacterType type) {
+    public JXMCharacter setType(CharacterType type) {
         this.type = type;
         return this;
     }

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/character/openxops/CharacterCodeGenerator.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/character/openxops/CharacterCodeGenerator.java
@@ -1,6 +1,6 @@
 package com.github.dabasan.jxm.properties.character.openxops;
 
-import com.github.dabasan.jxm.properties.character.Character;
+import com.github.dabasan.jxm.properties.character.JXMCharacter;
 import com.github.dabasan.jxm.properties.util.CPPArrayStringGenerator;
 
 import java.util.List;
@@ -41,7 +41,7 @@ public class CharacterCodeGenerator {
      * @param characters list containing character data
      * @return C++ code
      */
-    public String generate(List<Character> characters) {
+    public String generate(List<JXMCharacter> characters) {
         sb = new StringBuilder();
         for (int i = 0; i < characters.size(); i++) {
             var character = characters.get(i);

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/character/openxops/CharacterCodeParser.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/character/openxops/CharacterCodeParser.java
@@ -1,7 +1,6 @@
 package com.github.dabasan.jxm.properties.character.openxops;
 
 import com.github.dabasan.jxm.properties.character.*;
-import com.github.dabasan.jxm.properties.character.Character;
 import com.github.dabasan.jxm.properties.util.CPPArrayStringParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,8 +41,8 @@ public class CharacterCodeParser {
      * @param code C++ code
      * @return map containing character data
      */
-    public Map<Integer, Character> parse(List<String> code) {
-        var ret = new HashMap<Integer, Character>();
+    public Map<Integer, JXMCharacter> parse(List<String> code) {
+        var ret = new HashMap<Integer, JXMCharacter>();
 
         for (int i = 0; i < code.size(); i++) {
             var line = code.get(i);
@@ -63,7 +62,7 @@ public class CharacterCodeParser {
             }
 
             if (!ret.containsKey(arrayIndex)) {
-                var character = new Character();
+                var character = new JXMCharacter();
                 ret.put(arrayIndex, character);
             }
             var character = ret.get(arrayIndex);

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/character/xcs/XCSManipulator.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/character/xcs/XCSManipulator.java
@@ -1,6 +1,6 @@
 package com.github.dabasan.jxm.properties.character.xcs;
 
-import com.github.dabasan.jxm.properties.character.Character;
+import com.github.dabasan.jxm.properties.character.JXMCharacter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,13 +15,13 @@ public class XCSManipulator {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     private static final int NUM_CHARACTERS = 43;
-    private Character[] characters;
+    private JXMCharacter[] characters;
 
     /**
      * Creates a XCS manipulator.
      */
     public XCSManipulator() {
-        characters = new Character[NUM_CHARACTERS];
+        characters = new JXMCharacter[NUM_CHARACTERS];
     }
 
     private void readConstructorBase(InputStream is) throws IOException {
@@ -68,7 +68,7 @@ public class XCSManipulator {
      *
      * @return array containing character data
      */
-    public Character[] getCharacters() {
+    public JXMCharacter[] getCharacters() {
         return characters;
     }
 
@@ -77,7 +77,7 @@ public class XCSManipulator {
      *
      * @param characters array containing character data
      */
-    public void setCharacters(Character[] characters) {
+    public void setCharacters(JXMCharacter[] characters) {
         if (characters.length != NUM_CHARACTERS) {
             logger.warn("Invalid number of data contained in the array. number={}",
                     characters.length);

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/character/xcs/XCSReader.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/character/xcs/XCSReader.java
@@ -1,7 +1,6 @@
 package com.github.dabasan.jxm.properties.character.xcs;
 
 import com.github.dabasan.jxm.properties.character.*;
-import com.github.dabasan.jxm.properties.character.Character;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -15,18 +14,18 @@ import static com.github.dabasan.jxm.bintools.ByteFunctions.getUnsignedShortFrom
  * @author maeda6uiui
  */
 class XCSReader {
-    private final Character[] characters;
+    private final JXMCharacter[] characters;
 
     private int pos;
 
     public XCSReader(InputStream is, int numCharacters) throws IOException {
-        characters = new Character[numCharacters];
+        characters = new JXMCharacter[numCharacters];
 
         byte[] bin = is.readAllBytes();
         pos = 0x0000000C;
 
         for (int i = 0; i < numCharacters; i++) {
-            var character = new Character();
+            var character = new JXMCharacter();
 
             int textureTypeSpc = this.getShortAndIncrementPos(bin);
             character.texture = CharacterTextureType.values()[textureTypeSpc];
@@ -64,7 +63,7 @@ class XCSReader {
         return ret;
     }
 
-    public Character[] getCharacterData() {
+    public JXMCharacter[] getCharacterData() {
         return characters;
     }
 }

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/character/xcs/XCSWriter.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/character/xcs/XCSWriter.java
@@ -1,8 +1,8 @@
 package com.github.dabasan.jxm.properties.character.xcs;
 
-import com.github.dabasan.jxm.properties.character.Character;
 import com.github.dabasan.jxm.properties.character.CharacterBinEnumConverter;
 import com.github.dabasan.jxm.properties.character.CharacterModelType;
+import com.github.dabasan.jxm.properties.character.JXMCharacter;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -17,7 +17,7 @@ import static com.github.dabasan.jxm.bintools.ByteFunctions.addUnsignedShortToBi
  * @author maeda6uiui
  */
 class XCSWriter {
-    public void write(OutputStream os, Character[] characters) throws IOException {
+    public void write(OutputStream os, JXMCharacter[] characters) throws IOException {
         var bin = new ArrayList<Byte>();
 
         bin.add((byte) 0x58);//X
@@ -33,7 +33,7 @@ class XCSWriter {
         bin.add((byte) 0x07);
         bin.add((byte) 0x00);
 
-        for (Character character : characters) {
+        for (JXMCharacter character : characters) {
             addShortToBinLE(bin, (short) character.texture.ordinal());
 
             CharacterModelType modelType = character.model;

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/character/xops/BINCharacterManipulator.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/character/xops/BINCharacterManipulator.java
@@ -1,6 +1,6 @@
 package com.github.dabasan.jxm.properties.character.xops;
 
-import com.github.dabasan.jxm.properties.character.Character;
+import com.github.dabasan.jxm.properties.character.JXMCharacter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,13 +13,13 @@ public class BINCharacterManipulator {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     private static final int NUM_CHARACTERS = 43;
-    private Character[] characters;
+    private JXMCharacter[] characters;
 
     /**
      * Creates a BINCharacterManipulator instance.
      */
     public BINCharacterManipulator() {
-        characters = new Character[NUM_CHARACTERS];
+        characters = new JXMCharacter[NUM_CHARACTERS];
     }
 
     /**
@@ -38,7 +38,7 @@ public class BINCharacterManipulator {
      *
      * @return array containing character data
      */
-    public Character[] getCharacters() {
+    public JXMCharacter[] getCharacters() {
         return characters;
     }
 
@@ -47,7 +47,7 @@ public class BINCharacterManipulator {
      *
      * @param characters array containing character data
      */
-    public void setCharacters(Character[] characters) {
+    public void setCharacters(JXMCharacter[] characters) {
         if (characters.length != NUM_CHARACTERS) {
             logger.warn("Invalid number of data contained in the array. number={}",
                     characters.length);

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/character/xops/BINCharacterReader.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/character/xops/BINCharacterReader.java
@@ -1,7 +1,6 @@
 package com.github.dabasan.jxm.properties.character.xops;
 
 import com.github.dabasan.jxm.properties.character.*;
-import com.github.dabasan.jxm.properties.character.Character;
 
 import static com.github.dabasan.jxm.bintools.ByteFunctions.getShortFromBinLE;
 import static com.github.dabasan.jxm.bintools.ByteFunctions.getUnsignedShortFromBinLE;
@@ -12,15 +11,15 @@ import static com.github.dabasan.jxm.bintools.ByteFunctions.getUnsignedShortFrom
  * @author maeda6uiui
  */
 class BINCharacterReader {
-    private final Character[] characters;
+    private final JXMCharacter[] characters;
     private int pos;
 
     public BINCharacterReader(byte[] bin, int numCharacters, int dataStartPos) {
-        characters = new Character[numCharacters];
+        characters = new JXMCharacter[numCharacters];
 
         pos = dataStartPos;
         for (int i = 0; i < numCharacters; i++) {
-            var character = new Character();
+            var character = new JXMCharacter();
 
             int textureTypeSpc = this.getShortAndIncrementPos(bin);
             character.texture = CharacterTextureType.values()[textureTypeSpc];
@@ -58,7 +57,7 @@ class BINCharacterReader {
         return ret;
     }
 
-    public Character[] getCharacterData() {
+    public JXMCharacter[] getCharacterData() {
         return characters;
     }
 }

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/character/xops/BINCharacterWriter.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/character/xops/BINCharacterWriter.java
@@ -1,8 +1,8 @@
 package com.github.dabasan.jxm.properties.character.xops;
 
-import com.github.dabasan.jxm.properties.character.Character;
 import com.github.dabasan.jxm.properties.character.CharacterBinEnumConverter;
 import com.github.dabasan.jxm.properties.character.CharacterModelType;
+import com.github.dabasan.jxm.properties.character.JXMCharacter;
 
 import static com.github.dabasan.jxm.bintools.ByteFunctions.setShortToBinLE;
 import static com.github.dabasan.jxm.bintools.ByteFunctions.setUnsignedShortToBinLE;
@@ -15,9 +15,9 @@ import static com.github.dabasan.jxm.bintools.ByteFunctions.setUnsignedShortToBi
 class BINCharacterWriter {
     private int pos;
 
-    public void write(byte[] bin, Character[] characters, int dataStartPos) {
+    public void write(byte[] bin, JXMCharacter[] characters, int dataStartPos) {
         pos = dataStartPos;
-        for (Character character : characters) {
+        for (JXMCharacter character : characters) {
             this.setShortAndIncrementPos(bin, character.texture.ordinal());
 
             CharacterModelType modelType = character.model;

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/config/ConfigManipulator.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/config/ConfigManipulator.java
@@ -13,13 +13,13 @@ import java.io.*;
 public class ConfigManipulator {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    private Config config;
+    private JXMConfig config;
 
     /**
      * Creates a config manipulator.
      */
     public ConfigManipulator() {
-        config = new Config();
+        config = new JXMConfig();
     }
 
     private void readConstructorBase(InputStream is) throws IOException {
@@ -66,7 +66,7 @@ public class ConfigManipulator {
      *
      * @return config
      */
-    public Config getConfig() {
+    public JXMConfig getConfig() {
         return config;
     }
 
@@ -75,7 +75,7 @@ public class ConfigManipulator {
      *
      * @param config config to set
      */
-    public void setConfig(Config config) {
+    public void setConfig(JXMConfig config) {
         this.config = config;
     }
 

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/config/ConfigReader.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/config/ConfigReader.java
@@ -10,10 +10,10 @@ import java.util.function.Function;
  * @author maeda6uiui
  */
 class ConfigReader {
-    private final Config config;
+    private final JXMConfig config;
 
     public ConfigReader(InputStream is) throws IOException {
-        config = new Config();
+        config = new JXMConfig();
 
         //Read all bytes from a stream
         byte[] bin = is.readAllBytes();
@@ -73,7 +73,7 @@ class ConfigReader {
         return name.substring(0, firstNullPos);
     }
 
-    public Config getConfig() {
+    public JXMConfig getConfig() {
         return config;
     }
 }

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/config/ConfigWriter.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/config/ConfigWriter.java
@@ -13,7 +13,7 @@ import java.util.function.Function;
  * @author maeda6uiui
  */
 class ConfigWriter {
-    public void write(OutputStream os, Config config) throws IOException {
+    public void write(OutputStream os, JXMConfig config) throws IOException {
         var bin = new ArrayList<Byte>();
 
         bin.add((byte) config.turnUp.ordinal());

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/config/JXMConfig.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/config/JXMConfig.java
@@ -7,7 +7,7 @@ import java.util.Objects;
  *
  * @author maeda6uiui
  */
-public class Config {
+public class JXMConfig {
     //Key code
     public KeyCode turnUp;
     public KeyCode turnDown;
@@ -41,7 +41,7 @@ public class Config {
     /**
      * Creates a config instance.
      */
-    public Config() {
+    public JXMConfig() {
         this.reset();
     }
 
@@ -50,7 +50,7 @@ public class Config {
      *
      * @param config Config
      */
-    public Config(Config config) {
+    public JXMConfig(JXMConfig config) {
         this.turnUp = config.turnUp;
         this.turnDown = config.turnDown;
         this.turnLeft = config.turnLeft;
@@ -133,7 +133,7 @@ public class Config {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        Config config = (Config) o;
+        JXMConfig config = (JXMConfig) o;
         return mouseSensitivity == config.mouseSensitivity
                 && brightness == config.brightness
                 && enableSound == config.enableSound
@@ -196,137 +196,137 @@ public class Config {
         );
     }
 
-    public Config setTurnUp(KeyCode turnUp) {
+    public JXMConfig setTurnUp(KeyCode turnUp) {
         this.turnUp = turnUp;
         return this;
     }
 
-    public Config setTurnDown(KeyCode turnDown) {
+    public JXMConfig setTurnDown(KeyCode turnDown) {
         this.turnDown = turnDown;
         return this;
     }
 
-    public Config setTurnLeft(KeyCode turnLeft) {
+    public JXMConfig setTurnLeft(KeyCode turnLeft) {
         this.turnLeft = turnLeft;
         return this;
     }
 
-    public Config setTurnRight(KeyCode turnRight) {
+    public JXMConfig setTurnRight(KeyCode turnRight) {
         this.turnRight = turnRight;
         return this;
     }
 
-    public Config setMoveForward(KeyCode moveForward) {
+    public JXMConfig setMoveForward(KeyCode moveForward) {
         this.moveForward = moveForward;
         return this;
     }
 
-    public Config setMoveBackward(KeyCode moveBackward) {
+    public JXMConfig setMoveBackward(KeyCode moveBackward) {
         this.moveBackward = moveBackward;
         return this;
     }
 
-    public Config setMoveLeft(KeyCode moveLeft) {
+    public JXMConfig setMoveLeft(KeyCode moveLeft) {
         this.moveLeft = moveLeft;
         return this;
     }
 
-    public Config setMoveRight(KeyCode moveRight) {
+    public JXMConfig setMoveRight(KeyCode moveRight) {
         this.moveRight = moveRight;
         return this;
     }
 
-    public Config setWalk(KeyCode walk) {
+    public JXMConfig setWalk(KeyCode walk) {
         this.walk = walk;
         return this;
     }
 
-    public Config setJump(KeyCode jump) {
+    public JXMConfig setJump(KeyCode jump) {
         this.jump = jump;
         return this;
     }
 
-    public Config setReload(KeyCode reload) {
+    public JXMConfig setReload(KeyCode reload) {
         this.reload = reload;
         return this;
     }
 
-    public Config setDropWeapon(KeyCode dropWeapon) {
+    public JXMConfig setDropWeapon(KeyCode dropWeapon) {
         this.dropWeapon = dropWeapon;
         return this;
     }
 
-    public Config setZoom(KeyCode zoom) {
+    public JXMConfig setZoom(KeyCode zoom) {
         this.zoom = zoom;
         return this;
     }
 
-    public Config setFireMode(KeyCode fireMode) {
+    public JXMConfig setFireMode(KeyCode fireMode) {
         this.fireMode = fireMode;
         return this;
     }
 
-    public Config setSwitchWeapon(KeyCode switchWeapon) {
+    public JXMConfig setSwitchWeapon(KeyCode switchWeapon) {
         this.switchWeapon = switchWeapon;
         return this;
     }
 
-    public Config setWeapon1(KeyCode weapon1) {
+    public JXMConfig setWeapon1(KeyCode weapon1) {
         this.weapon1 = weapon1;
         return this;
     }
 
-    public Config setWeapon2(KeyCode weapon2) {
+    public JXMConfig setWeapon2(KeyCode weapon2) {
         this.weapon2 = weapon2;
         return this;
     }
 
-    public Config setFire(KeyCode fire) {
+    public JXMConfig setFire(KeyCode fire) {
         this.fire = fire;
         return this;
     }
 
-    public Config setMouseSensitivity(int mouseSensitivity) {
+    public JXMConfig setMouseSensitivity(int mouseSensitivity) {
         this.mouseSensitivity = mouseSensitivity;
         return this;
     }
 
-    public Config setBrightness(int brightness) {
+    public JXMConfig setBrightness(int brightness) {
         this.brightness = brightness;
         return this;
     }
 
-    public Config setWindowMode(WindowMode windowMode) {
+    public JXMConfig setWindowMode(WindowMode windowMode) {
         this.windowMode = windowMode;
         return this;
     }
 
-    public Config setEnableSound(boolean enableSound) {
+    public JXMConfig setEnableSound(boolean enableSound) {
         this.enableSound = enableSound;
         return this;
     }
 
-    public Config setEnableBlood(boolean enableBlood) {
+    public JXMConfig setEnableBlood(boolean enableBlood) {
         this.enableBlood = enableBlood;
         return this;
     }
 
-    public Config setInvertMouse(boolean invertMouse) {
+    public JXMConfig setInvertMouse(boolean invertMouse) {
         this.invertMouse = invertMouse;
         return this;
     }
 
-    public Config setFrameSkip(boolean frameSkip) {
+    public JXMConfig setFrameSkip(boolean frameSkip) {
         this.frameSkip = frameSkip;
         return this;
     }
 
-    public Config setAnotherGunsight(boolean anotherGunsight) {
+    public JXMConfig setAnotherGunsight(boolean anotherGunsight) {
         this.anotherGunsight = anotherGunsight;
         return this;
     }
 
-    public Config setName(String name) {
+    public JXMConfig setName(String name) {
         this.name = name;
         return this;
     }

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/JXMWeapon.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/JXMWeapon.java
@@ -7,7 +7,7 @@ import java.util.Objects;
  *
  * @author maeda6uiui
  */
-public class Weapon {
+public class JXMWeapon {
     public String name;
     public String model;
     public String texture;
@@ -44,7 +44,7 @@ public class Weapon {
     /**
      * Creates a weapon.
      */
-    public Weapon() {
+    public JXMWeapon() {
         name = "";
         model = "";
         texture = "";
@@ -84,7 +84,7 @@ public class Weapon {
      *
      * @param weapon Weapon
      */
-    public Weapon(Weapon weapon) {
+    public JXMWeapon(JXMWeapon weapon) {
         this.name = weapon.name;
         this.model = weapon.model;
         this.texture = weapon.texture;
@@ -161,7 +161,7 @@ public class Weapon {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        Weapon weapon = (Weapon) o;
+        JXMWeapon weapon = (JXMWeapon) o;
         return attackPower == weapon.attackPower
                 && penetration == weapon.penetration
                 && fireInterval == weapon.fireInterval
@@ -234,162 +234,162 @@ public class Weapon {
         );
     }
 
-    public Weapon setName(String name) {
+    public JXMWeapon setName(String name) {
         this.name = name;
         return this;
     }
 
-    public Weapon setModel(String model) {
+    public JXMWeapon setModel(String model) {
         this.model = model;
         return this;
     }
 
-    public Weapon setTexture(String texture) {
+    public JXMWeapon setTexture(String texture) {
         this.texture = texture;
         return this;
     }
 
-    public Weapon setAttackPower(int attackPower) {
+    public JXMWeapon setAttackPower(int attackPower) {
         this.attackPower = attackPower;
         return this;
     }
 
-    public Weapon setPenetration(int penetration) {
+    public JXMWeapon setPenetration(int penetration) {
         this.penetration = penetration;
         return this;
     }
 
-    public Weapon setFireInterval(int fireInterval) {
+    public JXMWeapon setFireInterval(int fireInterval) {
         this.fireInterval = fireInterval;
         return this;
     }
 
-    public Weapon setBulletSpeed(int bulletSpeed) {
+    public JXMWeapon setBulletSpeed(int bulletSpeed) {
         this.bulletSpeed = bulletSpeed;
         return this;
     }
 
-    public Weapon setMagazineCapacity(int magazineCapacity) {
+    public JXMWeapon setMagazineCapacity(int magazineCapacity) {
         this.magazineCapacity = magazineCapacity;
         return this;
     }
 
-    public Weapon setReloadTime(int reloadTime) {
+    public JXMWeapon setReloadTime(int reloadTime) {
         this.reloadTime = reloadTime;
         return this;
     }
 
-    public Weapon setRecoil(int recoil) {
+    public JXMWeapon setRecoil(int recoil) {
         this.recoil = recoil;
         return this;
     }
 
-    public Weapon setErrorRangeMin(int errorRangeMin) {
+    public JXMWeapon setErrorRangeMin(int errorRangeMin) {
         this.errorRangeMin = errorRangeMin;
         return this;
     }
 
-    public Weapon setErrorRangeMax(int errorRangeMax) {
+    public JXMWeapon setErrorRangeMax(int errorRangeMax) {
         this.errorRangeMax = errorRangeMax;
         return this;
     }
 
-    public Weapon setModelPositionX(float modelPositionX) {
+    public JXMWeapon setModelPositionX(float modelPositionX) {
         this.modelPositionX = modelPositionX;
         return this;
     }
 
-    public Weapon setModelPositionY(float modelPositionY) {
+    public JXMWeapon setModelPositionY(float modelPositionY) {
         this.modelPositionY = modelPositionY;
         return this;
     }
 
-    public Weapon setModelPositionZ(float modelPositionZ) {
+    public JXMWeapon setModelPositionZ(float modelPositionZ) {
         this.modelPositionZ = modelPositionZ;
         return this;
     }
 
-    public Weapon setMuzzleFlashPositionX(float muzzleFlashPositionX) {
+    public JXMWeapon setMuzzleFlashPositionX(float muzzleFlashPositionX) {
         this.muzzleFlashPositionX = muzzleFlashPositionX;
         return this;
     }
 
-    public Weapon setMuzzleFlashPositionY(float muzzleFlashPositionY) {
+    public JXMWeapon setMuzzleFlashPositionY(float muzzleFlashPositionY) {
         this.muzzleFlashPositionY = muzzleFlashPositionY;
         return this;
     }
 
-    public Weapon setMuzzleFlashPositionZ(float muzzleFlashPositionZ) {
+    public JXMWeapon setMuzzleFlashPositionZ(float muzzleFlashPositionZ) {
         this.muzzleFlashPositionZ = muzzleFlashPositionZ;
         return this;
     }
 
-    public Weapon setCartridgeEjectionPositionX(float cartridgeEjectionPositionX) {
+    public JXMWeapon setCartridgeEjectionPositionX(float cartridgeEjectionPositionX) {
         this.cartridgeEjectionPositionX = cartridgeEjectionPositionX;
         return this;
     }
 
-    public Weapon setCartridgeEjectionPositionY(float cartridgeEjectionPositionY) {
+    public JXMWeapon setCartridgeEjectionPositionY(float cartridgeEjectionPositionY) {
         this.cartridgeEjectionPositionY = cartridgeEjectionPositionY;
         return this;
     }
 
-    public Weapon setCartridgeEjectionPositionZ(float cartridgeEjectionPositionZ) {
+    public JXMWeapon setCartridgeEjectionPositionZ(float cartridgeEjectionPositionZ) {
         this.cartridgeEjectionPositionZ = cartridgeEjectionPositionZ;
         return this;
     }
 
-    public Weapon setCartridgeEjectionVelocityX(float cartridgeEjectionVelocityX) {
+    public JXMWeapon setCartridgeEjectionVelocityX(float cartridgeEjectionVelocityX) {
         this.cartridgeEjectionVelocityX = cartridgeEjectionVelocityX;
         return this;
     }
 
-    public Weapon setCartridgeEjectionVelocityY(float cartridgeEjectionVelocityY) {
+    public JXMWeapon setCartridgeEjectionVelocityY(float cartridgeEjectionVelocityY) {
         this.cartridgeEjectionVelocityY = cartridgeEjectionVelocityY;
         return this;
     }
 
-    public Weapon setRapidFire(boolean rapidFire) {
+    public JXMWeapon setRapidFire(boolean rapidFire) {
         this.rapidFire = rapidFire;
         return this;
     }
 
-    public Weapon setScopeMode(ScopeMode scopeMode) {
+    public JXMWeapon setScopeMode(ScopeMode scopeMode) {
         this.scopeMode = scopeMode;
         return this;
     }
 
-    public Weapon setModelScale(float modelScale) {
+    public JXMWeapon setModelScale(float modelScale) {
         this.modelScale = modelScale;
         return this;
     }
 
-    public Weapon setFireSoundId(int fireSoundId) {
+    public JXMWeapon setFireSoundId(int fireSoundId) {
         this.fireSoundId = fireSoundId;
         return this;
     }
 
-    public Weapon setFireSoundVolume(int fireSoundVolume) {
+    public JXMWeapon setFireSoundVolume(int fireSoundVolume) {
         this.fireSoundVolume = fireSoundVolume;
         return this;
     }
 
-    public Weapon setSuppressor(boolean suppressor) {
+    public JXMWeapon setSuppressor(boolean suppressor) {
         this.suppressor = suppressor;
         return this;
     }
 
-    public Weapon setShootingStance(ShootingStance shootingStance) {
+    public JXMWeapon setShootingStance(ShootingStance shootingStance) {
         this.shootingStance = shootingStance;
         return this;
     }
 
-    public Weapon setSwitchableWeaponId(int switchableWeaponId) {
+    public JXMWeapon setSwitchableWeaponId(int switchableWeaponId) {
         this.switchableWeaponId = switchableWeaponId;
         return this;
     }
 
-    public Weapon setNumProjectiles(int numProjectiles) {
+    public JXMWeapon setNumProjectiles(int numProjectiles) {
         this.numProjectiles = numProjectiles;
         return this;
     }

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/ids/IDSManipulator.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/ids/IDSManipulator.java
@@ -1,6 +1,6 @@
 package com.github.dabasan.jxm.properties.weapon.ids;
 
-import com.github.dabasan.jxm.properties.weapon.Weapon;
+import com.github.dabasan.jxm.properties.weapon.JXMWeapon;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,13 +14,13 @@ import java.io.*;
 public class IDSManipulator {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    private Weapon weapon;
+    private JXMWeapon weapon;
 
     /**
      * Creates an IDS manipulator.
      */
     public IDSManipulator() {
-        weapon = new Weapon();
+        weapon = new JXMWeapon();
     }
 
     private void readConstructorBase(InputStream is) throws IOException {
@@ -67,7 +67,7 @@ public class IDSManipulator {
      *
      * @return weapon data
      */
-    public Weapon getWeapon() {
+    public JXMWeapon getWeapon() {
         return weapon;
     }
 
@@ -76,7 +76,7 @@ public class IDSManipulator {
      *
      * @param weapon weapon data to set
      */
-    public void setWeapon(Weapon weapon) {
+    public void setWeapon(JXMWeapon weapon) {
         this.weapon = weapon;
     }
 

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/ids/IDSReader.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/ids/IDSReader.java
@@ -14,11 +14,11 @@ import static com.github.dabasan.jxm.bintools.ByteFunctions.getShortFromBinLE;
  * @author maeda6uiui
  */
 class IDSReader {
-    private final Weapon weapon;
+    private final JXMWeapon weapon;
     private int pos;
 
     public IDSReader(InputStream is) throws IOException {
-        weapon = new Weapon();
+        weapon = new JXMWeapon();
 
         byte[] bin = is.readAllBytes();
         pos = 0x0000000A;
@@ -99,7 +99,7 @@ class IDSReader {
         return name.substring(0, firstNullPos);
     }
 
-    public Weapon getWeaponData() {
+    public JXMWeapon getWeaponData() {
         return weapon;
     }
 }

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/ids/IDSWriter.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/ids/IDSWriter.java
@@ -15,7 +15,7 @@ import static com.github.dabasan.jxm.bintools.ByteFunctions.addShortToBinLE;
  * @author maeda6uiui
  */
 class IDSWriter {
-    public void write(OutputStream os, Weapon weapon) throws IOException {
+    public void write(OutputStream os, JXMWeapon weapon) throws IOException {
         var bin = new ArrayList<Byte>();
 
         bin.add((byte) 0x49);//I

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/openxops/WeaponCodeGenerator.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/openxops/WeaponCodeGenerator.java
@@ -1,7 +1,7 @@
 package com.github.dabasan.jxm.properties.weapon.openxops;
 
 import com.github.dabasan.jxm.properties.util.CPPArrayStringGenerator;
-import com.github.dabasan.jxm.properties.weapon.Weapon;
+import com.github.dabasan.jxm.properties.weapon.JXMWeapon;
 
 import java.util.List;
 
@@ -41,7 +41,7 @@ public class WeaponCodeGenerator {
      * @param weapons list containing weapon data
      * @return C++ code
      */
-    public String generate(List<Weapon> weapons) {
+    public String generate(List<JXMWeapon> weapons) {
         sb = new StringBuilder();
         for (int i = 0; i < weapons.size(); i++) {
             var weapon = weapons.get(i);

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/openxops/WeaponCodeParser.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/openxops/WeaponCodeParser.java
@@ -1,9 +1,9 @@
 package com.github.dabasan.jxm.properties.weapon.openxops;
 
 import com.github.dabasan.jxm.properties.util.CPPArrayStringParser;
+import com.github.dabasan.jxm.properties.weapon.JXMWeapon;
 import com.github.dabasan.jxm.properties.weapon.ScopeMode;
 import com.github.dabasan.jxm.properties.weapon.ShootingStance;
-import com.github.dabasan.jxm.properties.weapon.Weapon;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,8 +43,8 @@ public class WeaponCodeParser {
      * @param code C++ code
      * @return map containing weapon data
      */
-    public Map<Integer, Weapon> parse(List<String> code) {
-        var ret = new HashMap<Integer, Weapon>();
+    public Map<Integer, JXMWeapon> parse(List<String> code) {
+        var ret = new HashMap<Integer, JXMWeapon>();
 
         for (int i = 0; i < code.size(); i++) {
             var line = code.get(i);
@@ -64,7 +64,7 @@ public class WeaponCodeParser {
             }
 
             if (!ret.containsKey(arrayIndex)) {
-                var weapon = new Weapon();
+                var weapon = new JXMWeapon();
                 ret.put(arrayIndex, weapon);
             }
             var weapon = ret.get(arrayIndex);

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/xgs/XGSManipulator.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/xgs/XGSManipulator.java
@@ -1,6 +1,6 @@
 package com.github.dabasan.jxm.properties.weapon.xgs;
 
-import com.github.dabasan.jxm.properties.weapon.Weapon;
+import com.github.dabasan.jxm.properties.weapon.JXMWeapon;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,13 +15,13 @@ public class XGSManipulator {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     private static final int NUM_WEAPONS = 23;
-    private Weapon[] weapons;
+    private JXMWeapon[] weapons;
 
     /**
      * Creates a XGS manipulator.
      */
     public XGSManipulator() {
-        weapons = new Weapon[NUM_WEAPONS];
+        weapons = new JXMWeapon[NUM_WEAPONS];
     }
 
     private void readConstructorBase(InputStream is) throws IOException {
@@ -68,7 +68,7 @@ public class XGSManipulator {
      *
      * @return array containing weapon data
      */
-    public Weapon[] getWeapons() {
+    public JXMWeapon[] getWeapons() {
         return weapons;
     }
 
@@ -77,7 +77,7 @@ public class XGSManipulator {
      *
      * @param weapons array containing weapon data
      */
-    public void setWeapons(Weapon[] weapons) {
+    public void setWeapons(JXMWeapon[] weapons) {
         if (weapons.length != NUM_WEAPONS) {
             logger.warn("Invalid number of data contained in the array. number={}", weapons.length);
             return;

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/xgs/XGSReader.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/xgs/XGSReader.java
@@ -14,17 +14,17 @@ import static com.github.dabasan.jxm.bintools.ByteFunctions.getShortFromBinLE;
  * @author maeda6uiui
  */
 class XGSReader {
-    private final Weapon[] weapons;
+    private final JXMWeapon[] weapons;
     private int pos;
 
     public XGSReader(InputStream is, int numWeapons) throws IOException {
-        weapons = new Weapon[numWeapons];
+        weapons = new JXMWeapon[numWeapons];
 
         byte[] bin = is.readAllBytes();
         pos = 0x0000000E;
 
         for (int i = 0; i < numWeapons; i++) {
-            var weapon = new Weapon();
+            var weapon = new JXMWeapon();
 
             weapon.attackPower = this.getShortAndIncrementPos(bin);
             weapon.penetration = this.getShortAndIncrementPos(bin);
@@ -123,7 +123,7 @@ class XGSReader {
         return name.substring(0, firstNullPos);
     }
 
-    public Weapon[] getWeaponData() {
+    public JXMWeapon[] getWeaponData() {
         return weapons;
     }
 }

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/xgs/XGSWriter.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/xgs/XGSWriter.java
@@ -15,7 +15,7 @@ import static com.github.dabasan.jxm.bintools.ByteFunctions.addShortToBinLE;
  * @author maeda6uiui
  */
 class XGSWriter {
-    public void write(OutputStream os, Weapon[] weapons) throws IOException {
+    public void write(OutputStream os, JXMWeapon[] weapons) throws IOException {
         var bin = new ArrayList<Byte>();
 
         bin.add((byte) 0x58);//X
@@ -33,7 +33,7 @@ class XGSWriter {
         bin.add((byte) 0x08);
         bin.add((byte) 0x00);
 
-        for (Weapon weapon : weapons) {
+        for (JXMWeapon weapon : weapons) {
             addShortToBinLE(bin, (short) weapon.attackPower);
             addShortToBinLE(bin, (short) weapon.penetration);
             addShortToBinLE(bin, (short) weapon.fireInterval);

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/xops/BINWeaponManipulator.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/xops/BINWeaponManipulator.java
@@ -1,6 +1,6 @@
 package com.github.dabasan.jxm.properties.weapon.xops;
 
-import com.github.dabasan.jxm.properties.weapon.Weapon;
+import com.github.dabasan.jxm.properties.weapon.JXMWeapon;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,13 +13,13 @@ public class BINWeaponManipulator {
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     private static final int NUM_WEAPONS = 23;
-    private Weapon[] weapons;
+    private JXMWeapon[] weapons;
 
     /**
      * Creates a BINWeaponManipulator instance.
      */
     public BINWeaponManipulator() {
-        weapons = new Weapon[NUM_WEAPONS];
+        weapons = new JXMWeapon[NUM_WEAPONS];
     }
 
     /**
@@ -39,7 +39,7 @@ public class BINWeaponManipulator {
      *
      * @return array containing weapon data
      */
-    public Weapon[] getWeapons() {
+    public JXMWeapon[] getWeapons() {
         return weapons;
     }
 
@@ -48,7 +48,7 @@ public class BINWeaponManipulator {
      *
      * @param weapons array containing weapon data
      */
-    public void setWeapons(Weapon[] weapons) {
+    public void setWeapons(JXMWeapon[] weapons) {
         if (weapons.length != NUM_WEAPONS) {
             logger.warn("Invalid number of data contained in the array. number={}", weapons.length);
             return;

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/xops/BINWeaponReader.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/xops/BINWeaponReader.java
@@ -12,15 +12,15 @@ import static com.github.dabasan.jxm.bintools.ByteFunctions.getShortFromBinLE;
  * @author maeda6uiui
  */
 class BINWeaponReader {
-    private final Weapon[] weapons;
+    private final JXMWeapon[] weapons;
     private int pos;
 
     public BINWeaponReader(byte[] bin, int numWeapons, int dataStartPos, int nameStartPos) {
-        weapons = new Weapon[numWeapons];
+        weapons = new JXMWeapon[numWeapons];
 
         pos = dataStartPos;
         for (int i = 0; i < numWeapons; i++) {
-            var weapon = new Weapon();
+            var weapon = new JXMWeapon();
 
             weapon.attackPower = this.getShortAndIncrementPos(bin);
             weapon.penetration = this.getShortAndIncrementPos(bin);
@@ -120,7 +120,7 @@ class BINWeaponReader {
         return name.substring(0, firstNullPos);
     }
 
-    public Weapon[] getWeaponData() {
+    public JXMWeapon[] getWeaponData() {
         return weapons;
     }
 }

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/xops/BINWeaponWriter.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/xops/BINWeaponWriter.java
@@ -12,9 +12,9 @@ import static com.github.dabasan.jxm.bintools.ByteFunctions.setShortToBinLE;
 class BINWeaponWriter {
     private int pos;
 
-    public void write(byte[] bin, Weapon[] weapons, int dataStartPos, int nameStartPos) {
+    public void write(byte[] bin, JXMWeapon[] weapons, int dataStartPos, int nameStartPos) {
         pos = dataStartPos;
-        for (Weapon weapon : weapons) {
+        for (JXMWeapon weapon : weapons) {
             this.setShortAndIncrementPos(bin, weapon.attackPower);
             this.setShortAndIncrementPos(bin, weapon.penetration);
             this.setShortAndIncrementPos(bin, weapon.fireInterval);

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/xops/EXEManipulator.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/xops/EXEManipulator.java
@@ -2,7 +2,7 @@ package com.github.dabasan.jxm.properties.xops;
 
 import com.github.dabasan.jxm.properties.character.Character;
 import com.github.dabasan.jxm.properties.character.xops.BINCharacterManipulator;
-import com.github.dabasan.jxm.properties.weapon.Weapon;
+import com.github.dabasan.jxm.properties.weapon.JXMWeapon;
 import com.github.dabasan.jxm.properties.weapon.xops.BINWeaponManipulator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -171,7 +171,7 @@ public class EXEManipulator {
      *
      * @return array containing weapon data
      */
-    public Weapon[] getWeapons() {
+    public JXMWeapon[] getWeapons() {
         return weaponManipulator.getWeapons();
     }
 
@@ -180,7 +180,7 @@ public class EXEManipulator {
      *
      * @param weapons array containing weapon data
      */
-    public void setWeapons(Weapon[] weapons) {
+    public void setWeapons(JXMWeapon[] weapons) {
         weaponManipulator.setWeapons(weapons);
     }
 

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/xops/EXEManipulator.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/xops/EXEManipulator.java
@@ -1,6 +1,6 @@
 package com.github.dabasan.jxm.properties.xops;
 
-import com.github.dabasan.jxm.properties.character.Character;
+import com.github.dabasan.jxm.properties.character.JXMCharacter;
 import com.github.dabasan.jxm.properties.character.xops.BINCharacterManipulator;
 import com.github.dabasan.jxm.properties.weapon.JXMWeapon;
 import com.github.dabasan.jxm.properties.weapon.xops.BINWeaponManipulator;
@@ -189,7 +189,7 @@ public class EXEManipulator {
      *
      * @return array containing character data
      */
-    public Character[] getCharacters() {
+    public JXMCharacter[] getCharacters() {
         return characterManipulator.getCharacters();
     }
 
@@ -198,7 +198,7 @@ public class EXEManipulator {
      *
      * @param characters array containing character data
      */
-    public void setCharacters(Character[] characters) {
+    public void setCharacters(JXMCharacter[] characters) {
         characterManipulator.setCharacters(characters);
     }
 

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/CharacterCodeGeneratorTest.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/CharacterCodeGeneratorTest.java
@@ -1,6 +1,6 @@
 package com.github.dabasan.jxm.properties;
 
-import com.github.dabasan.jxm.properties.character.Character;
+import com.github.dabasan.jxm.properties.character.JXMCharacter;
 import com.github.dabasan.jxm.properties.character.openxops.CharacterCodeGenerator;
 import com.github.dabasan.jxm.properties.character.openxops.CharacterVariableNameSettings;
 import com.github.dabasan.jxm.properties.character.xcs.XCSManipulator;
@@ -42,7 +42,7 @@ public class CharacterCodeGeneratorTest {
 
         var generator = new CharacterCodeGenerator(settings);
 
-        Character[] characters = manipulator.getCharacters();
+        JXMCharacter[] characters = manipulator.getCharacters();
         String actualCode = generator.generate(Arrays.asList(characters));
         String[] actualLines = actualCode.split("\n");
         assertLinesMatch(expectedLines, Arrays.asList(actualLines));

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/CharacterCodeParserTest.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/CharacterCodeParserTest.java
@@ -1,6 +1,6 @@
 package com.github.dabasan.jxm.properties;
 
-import com.github.dabasan.jxm.properties.character.Character;
+import com.github.dabasan.jxm.properties.character.JXMCharacter;
 import com.github.dabasan.jxm.properties.character.openxops.CharacterCodeParser;
 import com.github.dabasan.jxm.properties.character.openxops.CharacterVariableNameSettings;
 import com.github.dabasan.jxm.properties.character.xcs.XCSManipulator;
@@ -24,7 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class CharacterCodeParserTest {
-    private Character[] expectedCharacters;
+    private JXMCharacter[] expectedCharacters;
     private List<String> codeLines;
 
     @BeforeAll
@@ -47,9 +47,9 @@ public class CharacterCodeParserTest {
         settings.texture = "テクスチャ";
 
         var parser = new CharacterCodeParser(settings);
-        Map<Integer, Character> actualCharacters = parser.parse(codeLines);
+        Map<Integer, JXMCharacter> actualCharacters = parser.parse(codeLines);
         actualCharacters.forEach((id, actualCharacter) -> {
-            Character expectedCharacter = expectedCharacters[id];
+            JXMCharacter expectedCharacter = expectedCharacters[id];
             assertEquals(expectedCharacter, actualCharacter);
         });
     }

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/ConfigManipulatorTest.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/ConfigManipulatorTest.java
@@ -1,7 +1,7 @@
 package com.github.dabasan.jxm.properties;
 
-import com.github.dabasan.jxm.properties.config.Config;
 import com.github.dabasan.jxm.properties.config.ConfigManipulator;
+import com.github.dabasan.jxm.properties.config.JXMConfig;
 import com.github.dabasan.jxm.properties.config.KeyCode;
 import com.github.dabasan.jxm.properties.config.WindowMode;
 import org.junit.jupiter.api.BeforeAll;
@@ -32,7 +32,7 @@ public class ConfigManipulatorTest {
 
     @Test
     public void testRead() {
-        Config expectedConfig = new Config()
+        JXMConfig expectedConfig = new JXMConfig()
                 .setTurnUp(KeyCode.KEY_UP)
                 .setTurnDown(KeyCode.KEY_DOWN)
                 .setTurnLeft(KeyCode.KEY_LEFT)
@@ -60,15 +60,15 @@ public class ConfigManipulatorTest {
                 .setFrameSkip(false)
                 .setAnotherGunsight(false)
                 .setName("maeda6uiui");
-        Config actualConfig = manipulator.getConfig();
+        JXMConfig actualConfig = manipulator.getConfig();
         assertEquals(expectedConfig, actualConfig);
     }
 
     @Test
     public void testUpdate() {
-        Config currentConfig = manipulator.getConfig();
+        JXMConfig currentConfig = manipulator.getConfig();
 
-        Config newConfig = TestUtils.generateRandomConfig();
+        JXMConfig newConfig = TestUtils.generateRandomConfig();
         manipulator.setConfig(newConfig);
         assertEquals(newConfig, manipulator.getConfig());
 

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/EXEManipulatorTest.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/EXEManipulatorTest.java
@@ -1,6 +1,6 @@
 package com.github.dabasan.jxm.properties;
 
-import com.github.dabasan.jxm.properties.character.Character;
+import com.github.dabasan.jxm.properties.character.JXMCharacter;
 import com.github.dabasan.jxm.properties.character.xcs.XCSManipulator;
 import com.github.dabasan.jxm.properties.weapon.JXMWeapon;
 import com.github.dabasan.jxm.properties.weapon.xgs.XGSManipulator;
@@ -31,7 +31,7 @@ public class EXEManipulatorTest {
     private Map<String, EXEManipulator> manipulators;
     private Map<String, XOPSVersion> expectedVersions;  //(filename, version)
     private JXMWeapon[] expectedWeapons;
-    private Character[] expectedCharacters;
+    private JXMCharacter[] expectedCharacters;
 
     @BeforeAll
     public void prepareForTest() {
@@ -108,7 +108,7 @@ public class EXEManipulatorTest {
     @Test
     public void testCharacters() {
         manipulators.values().forEach(manipulator -> {
-            Character[] actualCharacters = manipulator.getCharacters();
+            JXMCharacter[] actualCharacters = manipulator.getCharacters();
             assertArrayEquals(expectedCharacters, actualCharacters);
         });
     }
@@ -116,9 +116,9 @@ public class EXEManipulatorTest {
     @Test
     public void testUpdateCharacters() {
         manipulators.values().forEach(manipulator -> {
-            Character[] currentCharacters = manipulator.getCharacters();
+            JXMCharacter[] currentCharacters = manipulator.getCharacters();
 
-            var newCharacters = new Character[currentCharacters.length];
+            var newCharacters = new JXMCharacter[currentCharacters.length];
             for (int i = 0; i < currentCharacters.length; i++) {
                 newCharacters[i] = TestUtils.generateRandomCharacter();
             }

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/EXEManipulatorTest.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/EXEManipulatorTest.java
@@ -2,7 +2,7 @@ package com.github.dabasan.jxm.properties;
 
 import com.github.dabasan.jxm.properties.character.Character;
 import com.github.dabasan.jxm.properties.character.xcs.XCSManipulator;
-import com.github.dabasan.jxm.properties.weapon.Weapon;
+import com.github.dabasan.jxm.properties.weapon.JXMWeapon;
 import com.github.dabasan.jxm.properties.weapon.xgs.XGSManipulator;
 import com.github.dabasan.jxm.properties.xops.EXEManipulator;
 import com.github.dabasan.jxm.properties.xops.XOPSVersion;
@@ -30,7 +30,7 @@ public class EXEManipulatorTest {
     private static final String TARGET_DIR = "./TestData/XOPS";
     private Map<String, EXEManipulator> manipulators;
     private Map<String, XOPSVersion> expectedVersions;  //(filename, version)
-    private Weapon[] expectedWeapons;
+    private JXMWeapon[] expectedWeapons;
     private Character[] expectedCharacters;
 
     @BeforeAll
@@ -84,7 +84,7 @@ public class EXEManipulatorTest {
     @Test
     public void testWeapons() {
         manipulators.values().forEach(manipulator -> {
-            Weapon[] actualWeapons = manipulator.getWeapons();
+            JXMWeapon[] actualWeapons = manipulator.getWeapons();
             assertArrayEquals(expectedWeapons, actualWeapons);
         });
     }
@@ -92,9 +92,9 @@ public class EXEManipulatorTest {
     @Test
     public void testUpdateWeapons() {
         manipulators.values().forEach(manipulator -> {
-            Weapon[] currentWeapons = manipulator.getWeapons();
+            JXMWeapon[] currentWeapons = manipulator.getWeapons();
 
-            var newWeapons = new Weapon[currentWeapons.length];
+            var newWeapons = new JXMWeapon[currentWeapons.length];
             for (int i = 0; i < currentWeapons.length; i++) {
                 newWeapons[i] = TestUtils.generateRandomWeapon();
             }

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/IDSManipulatorTest.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/IDSManipulatorTest.java
@@ -1,6 +1,6 @@
 package com.github.dabasan.jxm.properties;
 
-import com.github.dabasan.jxm.properties.weapon.Weapon;
+import com.github.dabasan.jxm.properties.weapon.JXMWeapon;
 import com.github.dabasan.jxm.properties.weapon.ids.IDSManipulator;
 import com.github.dabasan.jxm.properties.weapon.xgs.XGSManipulator;
 import org.junit.jupiter.api.BeforeAll;
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class IDSManipulatorTest {
     private static final String TARGET_DIR = "./TestData/Weapon";
     private IDSManipulator manipulator;
-    private Weapon expectedWeapon;
+    private JXMWeapon expectedWeapon;
 
     @BeforeAll
     public void loadWeapon() {
@@ -35,15 +35,15 @@ public class IDSManipulatorTest {
 
     @Test
     public void testWeapon() {
-        Weapon actualWeapon = manipulator.getWeapon();
+        JXMWeapon actualWeapon = manipulator.getWeapon();
         assertEquals(expectedWeapon, actualWeapon);
     }
 
     @Test
     public void testUpdateWeapon() {
-        Weapon currentWeapon = manipulator.getWeapon();
+        JXMWeapon currentWeapon = manipulator.getWeapon();
 
-        Weapon newWeapon = TestUtils.generateRandomWeapon();
+        JXMWeapon newWeapon = TestUtils.generateRandomWeapon();
         manipulator.setWeapon(newWeapon);
         assertEquals(newWeapon, manipulator.getWeapon());
 

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/TestUtils.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/TestUtils.java
@@ -1,7 +1,6 @@
 package com.github.dabasan.jxm.properties;
 
 import com.github.dabasan.jxm.properties.character.*;
-import com.github.dabasan.jxm.properties.character.Character;
 import com.github.dabasan.jxm.properties.config.Config;
 import com.github.dabasan.jxm.properties.config.KeyCode;
 import com.github.dabasan.jxm.properties.config.WindowMode;
@@ -107,8 +106,8 @@ public class TestUtils {
                 .setNumProjectiles(random.nextInt());
     }
 
-    public static Character generateRandomCharacter() {
-        return new Character()
+    public static JXMCharacter generateRandomCharacter() {
+        return new JXMCharacter()
                 .setTexture(CharacterTextureType.values()[random.nextInt(CharacterTextureType.values().length)])
                 .setModel(CharacterModelType.values()[random.nextInt(CharacterModelType.values().length)])
                 .setAiLevel(AILevel.values()[random.nextInt(AILevel.values().length)])

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/TestUtils.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/TestUtils.java
@@ -5,9 +5,9 @@ import com.github.dabasan.jxm.properties.character.Character;
 import com.github.dabasan.jxm.properties.config.Config;
 import com.github.dabasan.jxm.properties.config.KeyCode;
 import com.github.dabasan.jxm.properties.config.WindowMode;
+import com.github.dabasan.jxm.properties.weapon.JXMWeapon;
 import com.github.dabasan.jxm.properties.weapon.ScopeMode;
 import com.github.dabasan.jxm.properties.weapon.ShootingStance;
-import com.github.dabasan.jxm.properties.weapon.Weapon;
 
 import java.io.BufferedInputStream;
 import java.io.FileInputStream;
@@ -71,8 +71,8 @@ public class TestUtils {
         return ret;
     }
 
-    public static Weapon generateRandomWeapon() {
-        return new Weapon()
+    public static JXMWeapon generateRandomWeapon() {
+        return new JXMWeapon()
                 .setName(generateRandomString(10))
                 .setModel(generateRandomString(20))
                 .setTexture(generateRandomString(20))

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/TestUtils.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/TestUtils.java
@@ -1,7 +1,7 @@
 package com.github.dabasan.jxm.properties;
 
 import com.github.dabasan.jxm.properties.character.*;
-import com.github.dabasan.jxm.properties.config.Config;
+import com.github.dabasan.jxm.properties.config.JXMConfig;
 import com.github.dabasan.jxm.properties.config.KeyCode;
 import com.github.dabasan.jxm.properties.config.WindowMode;
 import com.github.dabasan.jxm.properties.weapon.JXMWeapon;
@@ -115,8 +115,8 @@ public class TestUtils {
                 .setType(CharacterType.values()[random.nextInt(CharacterType.values().length)]);
     }
 
-    public static Config generateRandomConfig() {
-        return new Config()
+    public static JXMConfig generateRandomConfig() {
+        return new JXMConfig()
                 .setTurnUp(KeyCode.values()[random.nextInt(KeyCode.values().length)])
                 .setTurnDown(KeyCode.values()[random.nextInt(KeyCode.values().length)])
                 .setTurnLeft(KeyCode.values()[random.nextInt(KeyCode.values().length)])

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/WeaponCodeGeneratorTest.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/WeaponCodeGeneratorTest.java
@@ -1,6 +1,6 @@
 package com.github.dabasan.jxm.properties;
 
-import com.github.dabasan.jxm.properties.weapon.Weapon;
+import com.github.dabasan.jxm.properties.weapon.JXMWeapon;
 import com.github.dabasan.jxm.properties.weapon.openxops.WeaponCodeGenerator;
 import com.github.dabasan.jxm.properties.weapon.openxops.WeaponVariableNameSettings;
 import com.github.dabasan.jxm.properties.weapon.xgs.XGSManipulator;
@@ -42,7 +42,7 @@ public class WeaponCodeGeneratorTest {
 
         var generator = new WeaponCodeGenerator(settings);
 
-        Weapon[] weapons = manipulator.getWeapons();
+        JXMWeapon[] weapons = manipulator.getWeapons();
         String actualCode = generator.generate(Arrays.asList(weapons));
         String[] actualLines = actualCode.split("\n");
         assertLinesMatch(expectedLines, Arrays.asList(actualLines));

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/WeaponCodeParserTest.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/WeaponCodeParserTest.java
@@ -1,6 +1,6 @@
 package com.github.dabasan.jxm.properties;
 
-import com.github.dabasan.jxm.properties.weapon.Weapon;
+import com.github.dabasan.jxm.properties.weapon.JXMWeapon;
 import com.github.dabasan.jxm.properties.weapon.openxops.WeaponCodeParser;
 import com.github.dabasan.jxm.properties.weapon.openxops.WeaponVariableNameSettings;
 import com.github.dabasan.jxm.properties.weapon.xgs.XGSManipulator;
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class WeaponCodeParserTest {
-    private Weapon[] expectedWeapons;
+    private JXMWeapon[] expectedWeapons;
     private List<String> codeLines;
 
     @BeforeAll
@@ -42,9 +42,9 @@ public class WeaponCodeParserTest {
         settings.model = "モデル";
 
         var parser = new WeaponCodeParser(settings);
-        Map<Integer, Weapon> actualWeapons = parser.parse(codeLines);
+        Map<Integer, JXMWeapon> actualWeapons = parser.parse(codeLines);
         actualWeapons.forEach((id, actualWeapon) -> {
-            Weapon expectedWeapon = expectedWeapons[id];
+            JXMWeapon expectedWeapon = expectedWeapons[id];
             assertEquals(expectedWeapon, actualWeapon);
         });
     }

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/XCSManipulatorTest.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/XCSManipulatorTest.java
@@ -1,6 +1,6 @@
 package com.github.dabasan.jxm.properties;
 
-import com.github.dabasan.jxm.properties.character.Character;
+import com.github.dabasan.jxm.properties.character.JXMCharacter;
 import com.github.dabasan.jxm.properties.character.xcs.XCSManipulator;
 import com.github.dabasan.jxm.properties.xops.EXEManipulator;
 import org.junit.jupiter.api.BeforeAll;
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class XCSManipulatorTest {
     private static final String TARGET_DIR = "./TestData/Character";
     private XCSManipulator manipulator;
-    private Character[] expectedCharacters;
+    private JXMCharacter[] expectedCharacters;
 
     @BeforeAll
     public void loadCharacters() {
@@ -34,15 +34,15 @@ public class XCSManipulatorTest {
 
     @Test
     public void testCharacters() {
-        Character[] actualCharacters = manipulator.getCharacters();
+        JXMCharacter[] actualCharacters = manipulator.getCharacters();
         assertArrayEquals(expectedCharacters, actualCharacters);
     }
 
     @Test
     public void testUpdateCharacters() {
-        Character[] currentCharacters = manipulator.getCharacters();
+        JXMCharacter[] currentCharacters = manipulator.getCharacters();
 
-        var newCharacters = new Character[currentCharacters.length];
+        var newCharacters = new JXMCharacter[currentCharacters.length];
         for (int i = 0; i < currentCharacters.length; i++) {
             newCharacters[i] = TestUtils.generateRandomCharacter();
         }

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/XGSManipulatorTest.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/XGSManipulatorTest.java
@@ -1,6 +1,6 @@
 package com.github.dabasan.jxm.properties;
 
-import com.github.dabasan.jxm.properties.weapon.Weapon;
+import com.github.dabasan.jxm.properties.weapon.JXMWeapon;
 import com.github.dabasan.jxm.properties.weapon.xgs.XGSManipulator;
 import com.github.dabasan.jxm.properties.xops.EXEManipulator;
 import org.junit.jupiter.api.BeforeAll;
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.*;
 public class XGSManipulatorTest {
     private static final String TARGET_DIR = "./TestData/Weapon";
     private XGSManipulator manipulator;
-    private Weapon[] expectedWeapons;
+    private JXMWeapon[] expectedWeapons;
 
     @BeforeAll
     public void loadWeapons() {
@@ -34,15 +34,15 @@ public class XGSManipulatorTest {
 
     @Test
     public void testWeapons() {
-        Weapon[] actualWeapons = manipulator.getWeapons();
+        JXMWeapon[] actualWeapons = manipulator.getWeapons();
         assertArrayEquals(expectedWeapons, actualWeapons);
     }
 
     @Test
     public void testUpdateWeapons() {
-        Weapon[] currentWeapons = manipulator.getWeapons();
+        JXMWeapon[] currentWeapons = manipulator.getWeapons();
 
-        var newWeapons = new Weapon[currentWeapons.length];
+        var newWeapons = new JXMWeapon[currentWeapons.length];
         for (int i = 0; i < currentWeapons.length; i++) {
             newWeapons[i] = TestUtils.generateRandomWeapon();
         }


### PR DESCRIPTION
# Overview

Renamed some classes to avoid name collision with another class from external modules.
This renaming helps autocomplete functionality of IDEs.
