### PR TITLE
Use only Path for read and write of files

### DIFF
--- a/jxm-bd1/pom.xml
+++ b/jxm-bd1/pom.xml
@@ -58,5 +58,11 @@
             <artifactId>obj</artifactId>
             <version>0.4.0</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.19.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/jxm-bd1/src/main/java/com/github/dabasan/jxm/bd1/BD1Manipulator.java
+++ b/jxm-bd1/src/main/java/com/github/dabasan/jxm/bd1/BD1Manipulator.java
@@ -320,20 +320,20 @@ public class BD1Manipulator {
      * @param path Path of the output file
      * @throws IOException If it fails to write to the file
      */
-    public void saveAsBD1(Path path) throws IOException {
+    public void save(Path path) throws IOException {
         var writer = new BD1Writer();
         writer.write(path, blocks, textureFilenames);
     }
 
     /**
-     * Saves the block data in an OBJ file.
+     * Exports the block data to an OBJ file.
      *
      * @param objPath Path of the OBJ file
      * @param mtlPath Path of the MTL file
      * @param flipV   Flips texture V-coordinate if true
      * @throws IOException If it fails to write to the file
      */
-    public void saveAsOBJ(Path objPath, Path mtlPath, boolean flipV) throws IOException {
+    public void exportAsOBJ(Path objPath, Path mtlPath, boolean flipV) throws IOException {
         BD1OBJWriter.write(objPath, mtlPath, blocks, textureFilenames, flipV);
     }
 

--- a/jxm-bd1/src/main/java/com/github/dabasan/jxm/bd1/BD1Manipulator.java
+++ b/jxm-bd1/src/main/java/com/github/dabasan/jxm/bd1/BD1Manipulator.java
@@ -5,6 +5,7 @@ import org.joml.Matrix4fc;
 import org.joml.Vector3f;
 
 import java.io.*;
+import java.nio.file.Path;
 import java.util.*;
 
 /**
@@ -341,43 +342,15 @@ public class BD1Manipulator {
         return this;
     }
 
-    private void saveAsBD1Base(OutputStream os) throws IOException {
+    /**
+     * Saves the block data in a BD1 file.
+     *
+     * @param path Path of the output file
+     * @throws IOException If it fails to write to the file
+     */
+    public void saveAsBD1(Path path) throws IOException {
         var writer = new BD1Writer();
-        writer.write(os, blocks, textureFilenames);
-    }
-
-    /**
-     * Saves the blocks as a BD1.
-     *
-     * @param os output stream to write the blocks to
-     * @throws IOException if it fails to output
-     */
-    public void saveAsBD1(OutputStream os) throws IOException {
-        this.saveAsBD1Base(os);
-    }
-
-    /**
-     * Saves the blocks as a BD1.
-     *
-     * @param file file to write the blocks to
-     * @throws IOException if it fails to output
-     */
-    public void saveAsBD1(File file) throws IOException {
-        try (var bos = new BufferedOutputStream(new FileOutputStream(file))) {
-            this.saveAsBD1(bos);
-        }
-    }
-
-    /**
-     * Saves the blocks as a BD1.
-     *
-     * @param filepath filepath to write the blocks to
-     * @throws IOException if it fails to output
-     */
-    public void saveAsBD1(String filepath) throws IOException {
-        try (var bos = new BufferedOutputStream(new FileOutputStream(filepath))) {
-            this.saveAsBD1Base(bos);
-        }
+        writer.write(path, blocks, textureFilenames);
     }
 
     private void saveAsOBJBase(

--- a/jxm-bd1/src/main/java/com/github/dabasan/jxm/bd1/BD1Manipulator.java
+++ b/jxm-bd1/src/main/java/com/github/dabasan/jxm/bd1/BD1Manipulator.java
@@ -4,7 +4,7 @@ import org.joml.Matrix4f;
 import org.joml.Matrix4fc;
 import org.joml.Vector3f;
 
-import java.io.*;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
 
@@ -325,56 +325,16 @@ public class BD1Manipulator {
         writer.write(path, blocks, textureFilenames);
     }
 
-    private void saveAsOBJBase(
-            OutputStream osObj, OutputStream osMtl, String mtlFilename, boolean flipV) throws IOException {
-        BD1OBJWriter.write(osObj, osMtl, mtlFilename, blocks, textureFilenames, flipV);
-    }
-
     /**
-     * Saves the blocks as an OBJ.
+     * Saves the block data in an OBJ file.
      *
-     * @param osObj       output stream for OBJ
-     * @param osMtl       output stream for MTL
-     * @param mtlFilename filename of the MTL
-     * @param flipV       flips texture V-coordinate if true
-     * @throws IOException if it fails to output
+     * @param objPath Path of the OBJ file
+     * @param mtlPath Path of the MTL file
+     * @param flipV   Flips texture V-coordinate if true
+     * @throws IOException If it fails to write to the file
      */
-    public void saveAsOBJ(
-            OutputStream osObj, OutputStream osMtl, String mtlFilename, boolean flipV) throws IOException {
-        this.saveAsOBJBase(osObj, osMtl, mtlFilename, flipV);
-    }
-
-    /**
-     * Saves the blocks as an OBJ.
-     *
-     * @param fileObj     file for the OBJ
-     * @param fileMtl     file for the MTL
-     * @param mtlFilename filename of the MTL
-     * @param flipV       Flips texture V-coordinate if true
-     * @throws IOException if it fails to output
-     */
-    public void saveAsOBJ(File fileObj, File fileMtl, String mtlFilename, boolean flipV) throws IOException {
-        try (var bosObj = new BufferedOutputStream(new FileOutputStream(fileObj));
-             var bosMtl = new BufferedOutputStream(new FileOutputStream(fileMtl))) {
-            this.saveAsOBJBase(bosObj, bosMtl, mtlFilename, flipV);
-        }
-    }
-
-    /**
-     * Saves the blocks as an OBJ.
-     *
-     * @param filepathObj filepath of the OBJ
-     * @param filepathMtl filepath of the MTL
-     * @param mtlFilename filename of the MTL
-     * @param flipV       flips texture V-coordinate if true
-     * @throws IOException if it fails to output
-     */
-    public void saveAsOBJ(
-            String filepathObj, String filepathMtl, String mtlFilename, boolean flipV) throws IOException {
-        try (var bosObj = new BufferedOutputStream(new FileOutputStream(filepathObj));
-             var bosMtl = new BufferedOutputStream(new FileOutputStream(filepathMtl))) {
-            this.saveAsOBJBase(bosObj, bosMtl, mtlFilename, flipV);
-        }
+    public void saveAsObj(Path objPath, Path mtlPath, boolean flipV) throws IOException {
+        BD1OBJWriter.write(objPath, mtlPath, blocks, textureFilenames, flipV);
     }
 
     /**

--- a/jxm-bd1/src/main/java/com/github/dabasan/jxm/bd1/BD1Manipulator.java
+++ b/jxm-bd1/src/main/java/com/github/dabasan/jxm/bd1/BD1Manipulator.java
@@ -333,7 +333,7 @@ public class BD1Manipulator {
      * @param flipV   Flips texture V-coordinate if true
      * @throws IOException If it fails to write to the file
      */
-    public void saveAsObj(Path objPath, Path mtlPath, boolean flipV) throws IOException {
+    public void saveAsOBJ(Path objPath, Path mtlPath, boolean flipV) throws IOException {
         BD1OBJWriter.write(objPath, mtlPath, blocks, textureFilenames, flipV);
     }
 

--- a/jxm-bd1/src/main/java/com/github/dabasan/jxm/bd1/BD1Manipulator.java
+++ b/jxm-bd1/src/main/java/com/github/dabasan/jxm/bd1/BD1Manipulator.java
@@ -33,47 +33,19 @@ public class BD1Manipulator {
         transformationMat = new Matrix4f().identity();
     }
 
-    private void readConstructorBase(InputStream is) throws IOException {
-        var reader = new BD1Reader(is);
+    /**
+     * Creates a BD1 manipulator and loads a BD1 file.
+     *
+     * @param path Path of the BD1 file
+     * @throws IOException If it fails to load the BD1 file
+     */
+    public BD1Manipulator(Path path) throws IOException {
+        var reader = new BD1Reader(path);
 
         blocks = reader.getBlocks();
         textureFilenames = reader.getTextureFilenames();
 
         transformationMat = new Matrix4f().identity();
-    }
-
-    /**
-     * Creates a BD1 manipulator and loads a BD1.
-     *
-     * @param is input stream to load a BD1 from
-     * @throws IOException if it fails to load
-     */
-    public BD1Manipulator(InputStream is) throws IOException {
-        this.readConstructorBase(is);
-    }
-
-    /**
-     * Creates a BD1 manipulator and loads a BD1.
-     *
-     * @param file file to load a BD1 from
-     * @throws IOException if it fails to load
-     */
-    public BD1Manipulator(File file) throws IOException {
-        try (var bis = new BufferedInputStream(new FileInputStream(file))) {
-            this.readConstructorBase(bis);
-        }
-    }
-
-    /**
-     * Creates a BD1 manipulator and loads a BD1.
-     *
-     * @param filepath filepath to load a BD1 from
-     * @throws IOException if it fails to load
-     */
-    public BD1Manipulator(String filepath) throws IOException {
-        try (var bis = new BufferedInputStream(new FileInputStream(filepath))) {
-            this.readConstructorBase(bis);
-        }
     }
 
     /**

--- a/jxm-bd1/src/main/java/com/github/dabasan/jxm/bd1/BD1OBJWriter.java
+++ b/jxm-bd1/src/main/java/com/github/dabasan/jxm/bd1/BD1OBJWriter.java
@@ -3,8 +3,10 @@ package com.github.dabasan.jxm.bd1;
 import de.javagl.obj.*;
 import org.joml.Vector3fc;
 
+import java.io.BufferedOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -17,8 +19,8 @@ import java.util.Map;
  * @author maeda6uiui
  */
 class BD1OBJWriter {
-    public static void write(OutputStream osObj, OutputStream osMtl, String mtlFilename,
-                             List<BD1Block> blocks, Map<Integer, String> textureFilenames, boolean flipV)
+    public static void write(
+            Path objPath, Path mtlPath, List<BD1Block> blocks, Map<Integer, String> textureFilenames, boolean flipV)
             throws IOException {
         //Prepare faces
         Map<Integer, List<BD1Face>> facesMap = BD1FaceGenerator.generateFaces(blocks);
@@ -27,7 +29,7 @@ class BD1OBJWriter {
         Obj obj = Objs.create();
         var mtls = new ArrayList<Mtl>();
 
-        obj.setMtlFileNames(Collections.singletonList(mtlFilename));
+        obj.setMtlFileNames(Collections.singletonList(mtlPath.getFileName().toString()));
         obj.setActiveGroupNames(Collections.singletonList("map"));
 
         int countIndex = 0;
@@ -80,8 +82,12 @@ class BD1OBJWriter {
             }
         }
 
-        ObjWriter.write(obj, osObj);
-        MtlWriter.write(mtls, osMtl);
+        try (var bosObj = new BufferedOutputStream(Files.newOutputStream(objPath))) {
+            ObjWriter.write(obj, bosObj);
+        }
+        try (var bosMtl = new BufferedOutputStream(Files.newOutputStream(mtlPath))) {
+            MtlWriter.write(mtls, bosMtl);
+        }
     }
 
     private static String getFilepathWithoutExtension(String filepath) {

--- a/jxm-bd1/src/main/java/com/github/dabasan/jxm/bd1/BD1Reader.java
+++ b/jxm-bd1/src/main/java/com/github/dabasan/jxm/bd1/BD1Reader.java
@@ -1,7 +1,8 @@
 package com.github.dabasan.jxm.bd1;
 
 import java.io.IOException;
-import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -19,12 +20,12 @@ class BD1Reader {
     private final Map<Integer, String> textureFilenames;
     private final List<BD1Block> blocks;
 
-    public BD1Reader(InputStream is) throws IOException, IndexOutOfBoundsException {
+    public BD1Reader(Path path) throws IOException, IndexOutOfBoundsException {
         textureFilenames = new HashMap<>();
         blocks = new ArrayList<>();
 
-        //Read all bytes from a stream
-        byte[] bin = is.readAllBytes();
+        //Read all bytes
+        byte[] bin = Files.readAllBytes(path);
 
         int pos = 0;
 

--- a/jxm-bd1/src/main/java/com/github/dabasan/jxm/bd1/BD1Writer.java
+++ b/jxm-bd1/src/main/java/com/github/dabasan/jxm/bd1/BD1Writer.java
@@ -1,9 +1,11 @@
 package com.github.dabasan.jxm.bd1;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.joml.Vector3fc;
 
 import java.io.IOException;
-import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 
 import static com.github.dabasan.jxm.bintools.ByteFunctions.addFloatToBinLE;
@@ -15,7 +17,7 @@ import static com.github.dabasan.jxm.bintools.ByteFunctions.addUnsignedShortToBi
  * @author maeda6uiui
  */
 class BD1Writer {
-    public void write(OutputStream os, List<BD1Block> blocks, Map<Integer, String> textureFilenames)
+    public void write(Path path, List<BD1Block> blocks, Map<Integer, String> textureFilenames)
             throws IOException {
         List<Byte> bin = new ArrayList<>();
 
@@ -79,9 +81,9 @@ class BD1Writer {
             }
         }
 
-        for (byte b : bin) {
-            os.write(b);
-        }
+        Byte[] boxedBytes = bin.toArray(Byte[]::new);
+        byte[] byteArray = ArrayUtils.toPrimitive(boxedBytes);
+        Files.write(path, byteArray);
     }
 
     private void addTextureFilenamesToBin(List<Byte> bin, Map<Integer, String> textureFilenames) {

--- a/jxm-bd1/src/main/java/module-info.java
+++ b/jxm-bd1/src/main/java/module-info.java
@@ -5,4 +5,5 @@ module com.github.dabasan.jxm.bd1 {
     requires transitive org.slf4j;
     requires obj;
     requires com.github.dabasan.jxm.bintools;
+    requires org.apache.commons.lang3;
 }

--- a/jxm-bd1/src/test/java/com/github/dabasan/jxm/bd1/BD1ManipulatorSnowBaseTest.java
+++ b/jxm-bd1/src/test/java/com/github/dabasan/jxm/bd1/BD1ManipulatorSnowBaseTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
@@ -27,7 +28,7 @@ public class BD1ManipulatorSnowBaseTest {
     @BeforeAll
     public void loadBD1() {
         assertDoesNotThrow(() -> {
-            manipulator = new BD1Manipulator(Paths.get(TARGET_DIR, "map.bd1").toString());
+            manipulator = new BD1Manipulator(Paths.get(TARGET_DIR, "map.bd1"));
         });
 
         origBlocks = new ArrayList<>();
@@ -80,9 +81,7 @@ public class BD1ManipulatorSnowBaseTest {
                 .rotate((float) Math.PI / 4.0f, 0.0f, 0.0f, 1.0f)
                 .scale(1.0f, 2.0f, 1.0f);
         manipulator.transform(mat).applyTransformation();
-
-        var saveFilepath = Paths.get(TARGET_DIR, "transform.bd1").toString();
-        assertDoesNotThrow(() -> manipulator.saveAsBD1(saveFilepath));
+        assertDoesNotThrow(() -> manipulator.save(Paths.get(TARGET_DIR, "transform.bd1")));
     }
 
     @Test
@@ -91,45 +90,35 @@ public class BD1ManipulatorSnowBaseTest {
         float amountY = 50.0f;
         float amountZ = 50.0f;
         manipulator.translate(amountX, amountY, amountZ).applyTransformation();
-
-        var saveFilepath = Paths.get(TARGET_DIR, "translate.bd1").toString();
-        assertDoesNotThrow(() -> manipulator.saveAsBD1(saveFilepath));
+        assertDoesNotThrow(() -> manipulator.save(Paths.get(TARGET_DIR, "translate.bd1")));
     }
 
     @Test
     public void rotX() {
         float amount = (float) Math.PI / 4.0f;
         manipulator.rotX(amount).applyTransformation();
-
-        var saveFilepath = Paths.get(TARGET_DIR, "rot_x.bd1").toString();
-        assertDoesNotThrow(() -> manipulator.saveAsBD1(saveFilepath));
+        assertDoesNotThrow(() -> manipulator.save(Paths.get(TARGET_DIR, "rot_x.bd1")));
     }
 
     @Test
     public void rotY() {
         float amount = (float) Math.PI / 4.0f;
         manipulator.rotY(amount).applyTransformation();
-
-        var saveFilepath = Paths.get(TARGET_DIR, "rot_y.bd1").toString();
-        assertDoesNotThrow(() -> manipulator.saveAsBD1(saveFilepath));
+        assertDoesNotThrow(() -> manipulator.save(Paths.get(TARGET_DIR, "rot_y.bd1")));
     }
 
     @Test
     public void rotZ() {
         float amount = (float) Math.PI / 4.0f;
         manipulator.rotZ(amount).applyTransformation();
-
-        var saveFilepath = Paths.get(TARGET_DIR, "rot_z.bd1").toString();
-        assertDoesNotThrow(() -> manipulator.saveAsBD1(saveFilepath));
+        assertDoesNotThrow(() -> manipulator.save(Paths.get(TARGET_DIR, "rot_z.bd1")));
     }
 
     @Test
     public void rot() {
         float amount = (float) Math.PI / 4.0f;
         manipulator.rot(amount, 1.0f, 1.0f, 1.0f).applyTransformation();
-
-        var saveFilepath = Paths.get(TARGET_DIR, "rot.bd1").toString();
-        assertDoesNotThrow(() -> manipulator.saveAsBD1(saveFilepath));
+        assertDoesNotThrow(() -> manipulator.save(Paths.get(TARGET_DIR, "rot.bd1")));
     }
 
     @Test
@@ -138,25 +127,20 @@ public class BD1ManipulatorSnowBaseTest {
         float scaleY = 2.0f;
         float scaleZ = 2.0f;
         manipulator.rescale(scaleX, scaleY, scaleZ).applyTransformation();
-
-        var saveFilepath = Paths.get(TARGET_DIR, "rescale.bd1").toString();
-        assertDoesNotThrow(() -> manipulator.saveAsBD1(saveFilepath));
+        assertDoesNotThrow(() -> manipulator.save(Paths.get(TARGET_DIR, "rescale.bd1")));
     }
 
     @Test
     public void invertZ() {
         manipulator.invertZ();
-
-        var saveFilepath = Paths.get(TARGET_DIR, "invert_z.bd1").toString();
-        assertDoesNotThrow(() -> manipulator.saveAsBD1(saveFilepath));
+        assertDoesNotThrow(() -> manipulator.save(Paths.get(TARGET_DIR, "invert_z.bd1")));
     }
 
     @Test
     public void testUpdate() {
         List<BD1Block> tmpBlocks;
         try {
-            var tmpFilepath = Paths.get(TARGET_DIR, "map_2.bd1").toString();
-            var tmpManipulator = new BD1Manipulator(tmpFilepath);
+            var tmpManipulator = new BD1Manipulator(Paths.get(TARGET_DIR, "map_2.bd1"));
             tmpBlocks = tmpManipulator.getBlocks();
         } catch (IOException e) {
             fail(e);
@@ -168,15 +152,15 @@ public class BD1ManipulatorSnowBaseTest {
     }
 
     @Test
-    public void saveAsOBJ() {
-        var objFilepath = Paths.get(TARGET_DIR, "map.obj").toString();
-        var mtlFilepath = Paths.get(TARGET_DIR, "map.mtl").toString();
+    public void exportAsOBJ() {
+        Path objPath = Paths.get(TARGET_DIR, "map.obj");
+        Path mtlPath = Paths.get(TARGET_DIR, "map.mtl");
         assertDoesNotThrow(
-                () -> manipulator.saveAsOBJ(objFilepath, mtlFilepath, "map.mtl", false));
+                () -> manipulator.exportAsOBJ(objPath, mtlPath, false));
 
-        var objFlipFilepath = Paths.get(TARGET_DIR, "map_flip.obj").toString();
-        var mtlFlipFilepath = Paths.get(TARGET_DIR, "map_flip.mtl").toString();
+        Path objFlipPath = Paths.get(TARGET_DIR, "map_flip.obj");
+        Path mtlFlipPath = Paths.get(TARGET_DIR, "map_flip.mtl");
         assertDoesNotThrow(
-                () -> manipulator.saveAsOBJ(objFlipFilepath, mtlFlipFilepath, "map_flip.mtl", true));
+                () -> manipulator.exportAsOBJ(objFlipPath, mtlFlipPath, true));
     }
 }

--- a/jxm-bd1/src/test/java/com/github/dabasan/jxm/bd1/BD1ManipulatorTrainingYardTest.java
+++ b/jxm-bd1/src/test/java/com/github/dabasan/jxm/bd1/BD1ManipulatorTrainingYardTest.java
@@ -21,22 +21,22 @@ public class BD1ManipulatorTrainingYardTest {
     @BeforeAll
     public void loadBD1() {
         assertDoesNotThrow(() -> {
-            manipulator = new BD1Manipulator(Paths.get(TARGET_DIR, "map.bd1").toString());
+            manipulator = new BD1Manipulator(Paths.get(TARGET_DIR, "map.bd1"));
         });
     }
 
     @Test
-    public void saveAsOBJ() {
+    public void exportAsOBJ() {
         manipulator.invertZ();
 
-        var objFilepath = Paths.get(TARGET_DIR, "map.obj").toString();
-        var mtlFilepath = Paths.get(TARGET_DIR, "map.mtl").toString();
+        var objPath = Paths.get(TARGET_DIR, "map.obj");
+        var mtlPath = Paths.get(TARGET_DIR, "map.mtl");
         assertDoesNotThrow(
-                () -> manipulator.saveAsOBJ(objFilepath, mtlFilepath, "map.mtl", false));
+                () -> manipulator.exportAsOBJ(objPath, mtlPath, false));
 
-        var objFlipFilepath = Paths.get(TARGET_DIR, "map_flip.obj").toString();
-        var mtlFlipFilepath = Paths.get(TARGET_DIR, "map_flip.mtl").toString();
+        var objFlipPath = Paths.get(TARGET_DIR, "map_flip.obj");
+        var mtlFlipPath = Paths.get(TARGET_DIR, "map_flip.mtl");
         assertDoesNotThrow(
-                () -> manipulator.saveAsOBJ(objFlipFilepath, mtlFlipFilepath, "map_flip.mtl", true));
+                () -> manipulator.exportAsOBJ(objFlipPath, mtlFlipPath, true));
     }
 }

--- a/jxm-mif/src/main/java/com/github/dabasan/jxm/mif/MIFManipulator.java
+++ b/jxm-mif/src/main/java/com/github/dabasan/jxm/mif/MIFManipulator.java
@@ -55,7 +55,7 @@ public class MIFManipulator {
      * @param encoding Encoding of the MIF file
      * @throws IOException If it fails to write to the file
      */
-    public void saveAsMIF(Path path, String encoding) throws IOException {
+    public void save(Path path, String encoding) throws IOException {
         var writer = new MIFWriter();
         writer.write(path, encoding, missionInfo);
     }

--- a/jxm-mif/src/main/java/com/github/dabasan/jxm/mif/MIFManipulator.java
+++ b/jxm-mif/src/main/java/com/github/dabasan/jxm/mif/MIFManipulator.java
@@ -1,6 +1,7 @@
 package com.github.dabasan.jxm.mif;
 
-import java.io.*;
+import java.io.IOException;
+import java.nio.file.Path;
 
 /**
  * MIF manipulator
@@ -17,46 +18,16 @@ public class MIFManipulator {
         missionInfo = new MissionInfo();
     }
 
-    private void readConstructorBase(InputStream is, String encoding) throws IOException {
-        var reader = new MIFReader(is, encoding);
+    /**
+     * Creates a MIF manipulator and loads a MIF file.
+     *
+     * @param path     Path of the MIF file
+     * @param encoding Encoding of the MIF
+     * @throws IOException If it fails to load the MIF file
+     */
+    public MIFManipulator(Path path, String encoding) throws IOException {
+        var reader = new MIFReader(path, encoding);
         missionInfo = reader.getMissionInfo();
-    }
-
-    /**
-     * Creates a MIF manipulator and loads a MIF.
-     *
-     * @param is       input stream to load the MIF from
-     * @param encoding encoding of the MIF
-     * @throws IOException if it fails to load
-     */
-    public MIFManipulator(InputStream is, String encoding) throws IOException {
-        this.readConstructorBase(is, encoding);
-    }
-
-    /**
-     * Creates a MIF manipulator and loads a MIF.
-     *
-     * @param file     file to load the MIF from
-     * @param encoding encoding of the MIF
-     * @throws IOException if it fails to load
-     */
-    public MIFManipulator(File file, String encoding) throws IOException {
-        try (var fis = new FileInputStream(file)) {
-            this.readConstructorBase(fis, encoding);
-        }
-    }
-
-    /**
-     * Creates a MIF manipulator and loads a MIF.
-     *
-     * @param filepath filepath to load the MIF from
-     * @param encoding encoding of the MIF
-     * @throws IOException if it fails to load
-     */
-    public MIFManipulator(String filepath, String encoding) throws IOException {
-        try (var fis = new FileInputStream(filepath)) {
-            this.readConstructorBase(fis, encoding);
-        }
     }
 
     /**
@@ -77,45 +48,15 @@ public class MIFManipulator {
         this.missionInfo = missionInfo;
     }
 
-    private void saveAsMIFBase(OutputStream os, String encoding) throws IOException {
+    /**
+     * Saves the mission info in a MIF file.
+     *
+     * @param path     Path of the MIF file
+     * @param encoding Encoding of the MIF file
+     * @throws IOException If it fails to write to the file
+     */
+    public void saveAsMIF(Path path, String encoding) throws IOException {
         var writer = new MIFWriter();
-        writer.write(os, encoding, missionInfo);
-    }
-
-    /**
-     * Saves the mission info as a MIF.
-     *
-     * @param os       output stream to write the MIF to
-     * @param encoding encoding of the MIF
-     * @throws IOException if it fails to output
-     */
-    public void saveAsMIF(OutputStream os, String encoding) throws IOException {
-        this.saveAsMIFBase(os, encoding);
-    }
-
-    /**
-     * Saves the mission info as a MIF.
-     *
-     * @param file     file to write the MIF to
-     * @param encoding encoding of the MIF
-     * @throws IOException if it fails to output
-     */
-    public void saveAsMIF(File file, String encoding) throws IOException {
-        try (var fos = new FileOutputStream(file)) {
-            this.saveAsMIFBase(fos, encoding);
-        }
-    }
-
-    /**
-     * Saves the mission info as a MIF.
-     *
-     * @param filepath filepath
-     * @param encoding encoding of the MIF
-     * @throws IOException if it fails to output
-     */
-    public void saveAsMIF(String filepath, String encoding) throws IOException {
-        try (var fos = new FileOutputStream(filepath)) {
-            this.saveAsMIFBase(fos, encoding);
-        }
+        writer.write(path, encoding, missionInfo);
     }
 }

--- a/jxm-mif/src/main/java/com/github/dabasan/jxm/mif/MIFReader.java
+++ b/jxm-mif/src/main/java/com/github/dabasan/jxm/mif/MIFReader.java
@@ -1,10 +1,11 @@
 package com.github.dabasan.jxm.mif;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * MIF reader
@@ -14,22 +15,10 @@ import java.util.ArrayList;
 class MIFReader {
     private final MissionInfo missionInfo;
 
-    public MIFReader(InputStream is, String encoding) throws IOException, NumberFormatException {
+    public MIFReader(Path path, String encoding) throws IOException, NumberFormatException {
+        List<String> lines = Files.readAllLines(path, Charset.forName(encoding));
+
         missionInfo = new MissionInfo();
-
-        //Read all lines from a file
-        var lines = new ArrayList<String>();
-        try (var br = new BufferedReader(new InputStreamReader(is, encoding))) {
-            while (true) {
-                String line = br.readLine();
-                if (line == null) {
-                    break;
-                }
-
-                lines.add(line);
-            }
-        }
-
         missionInfo.missionTitle = lines.get(0);
         missionInfo.missionFullname = lines.get(1);
         missionInfo.pathnameOfBlock = lines.get(2);

--- a/jxm-mif/src/main/java/com/github/dabasan/jxm/mif/MIFWriter.java
+++ b/jxm-mif/src/main/java/com/github/dabasan/jxm/mif/MIFWriter.java
@@ -1,9 +1,9 @@
 package com.github.dabasan.jxm.mif;
 
-import java.io.BufferedWriter;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -13,7 +13,7 @@ import java.util.List;
  * @author maeda6uiui
  */
 class MIFWriter {
-    public void write(OutputStream os, String encoding, MissionInfo missionInfo)
+    public void write(Path path, String encoding, MissionInfo missionInfo)
             throws IOException {
         var lines = new ArrayList<String>();
 
@@ -39,15 +39,13 @@ class MIFWriter {
         lines.add(missionInfo.pathnameOfImage2);
 
         List<String> briefingText = missionInfo.briefingText;
-        for (var line : briefingText) {
-            lines.add(line);
-        }
+        lines.addAll(briefingText);
 
-        try (var bw = new BufferedWriter(new OutputStreamWriter(os, encoding))) {
-            for (var line : lines) {
-                bw.write(line);
-                bw.newLine();
-            }
-        }
+        var sb = new StringBuilder();
+        lines.forEach(line -> {
+            sb.append(line);
+            sb.append(System.lineSeparator());
+        });
+        Files.writeString(path, sb, Charset.forName(encoding));
     }
 }

--- a/jxm-mif/src/test/java/com/github/dabasan/jxm/mif/MIFManipulatorTest.java
+++ b/jxm-mif/src/test/java/com/github/dabasan/jxm/mif/MIFManipulatorTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 
@@ -23,7 +24,7 @@ public class MIFManipulatorTest {
     @BeforeAll
     public void loadMIF() {
         assertDoesNotThrow(() -> {
-            manipulator = new MIFManipulator(Paths.get(TARGET_DIR, "src.mif").toString(), "Shift-JIS");
+            manipulator = new MIFManipulator(Paths.get(TARGET_DIR, "src.mif"), "Shift-JIS");
         });
     }
 
@@ -67,10 +68,10 @@ public class MIFManipulatorTest {
 
     @Test
     public void saveAsMIF() {
-        var saveFilepath = Paths.get(TARGET_DIR, "dst_shift_jis.mif").toString();
-        assertDoesNotThrow(() -> manipulator.saveAsMIF(saveFilepath, "Shift-JIS"));
+        Path path = Paths.get(TARGET_DIR, "dst_shift_jis.mif");
+        assertDoesNotThrow(() -> manipulator.saveAsMIF(path, "Shift-JIS"));
 
-        var saveFilepath2 = Paths.get(TARGET_DIR, "dst_utf_8.mif").toString();
-        assertDoesNotThrow(() -> manipulator.saveAsMIF(saveFilepath2, "UTF-8"));
+        Path path2 = Paths.get(TARGET_DIR, "dst_utf_8.mif");
+        assertDoesNotThrow(() -> manipulator.saveAsMIF(path2, "UTF-8"));
     }
 }

--- a/jxm-mif/src/test/java/com/github/dabasan/jxm/mif/MIFManipulatorTest.java
+++ b/jxm-mif/src/test/java/com/github/dabasan/jxm/mif/MIFManipulatorTest.java
@@ -67,11 +67,11 @@ public class MIFManipulatorTest {
     }
 
     @Test
-    public void saveAsMIF() {
+    public void testSave() {
         Path path = Paths.get(TARGET_DIR, "dst_shift_jis.mif");
-        assertDoesNotThrow(() -> manipulator.saveAsMIF(path, "Shift-JIS"));
+        assertDoesNotThrow(() -> manipulator.save(path, "Shift-JIS"));
 
         Path path2 = Paths.get(TARGET_DIR, "dst_utf_8.mif");
-        assertDoesNotThrow(() -> manipulator.saveAsMIF(path2, "UTF-8"));
+        assertDoesNotThrow(() -> manipulator.save(path2, "UTF-8"));
     }
 }

--- a/jxm-pd1/pom.xml
+++ b/jxm-pd1/pom.xml
@@ -52,5 +52,11 @@
             <artifactId>joml</artifactId>
             <version>1.10.5</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.19.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/jxm-pd1/src/main/java/com/github/dabasan/jxm/pd1/PD1Manipulator.java
+++ b/jxm-pd1/src/main/java/com/github/dabasan/jxm/pd1/PD1Manipulator.java
@@ -253,7 +253,7 @@ public class PD1Manipulator {
      * @param path Path of the PD1 file
      * @throws IOException If it fails to write to the file
      */
-    public void saveAsPD1(Path path) throws IOException {
+    public void save(Path path) throws IOException {
         var writer = new PD1Writer();
         writer.write(path, points);
     }

--- a/jxm-pd1/src/main/java/com/github/dabasan/jxm/pd1/PD1Manipulator.java
+++ b/jxm-pd1/src/main/java/com/github/dabasan/jxm/pd1/PD1Manipulator.java
@@ -4,7 +4,8 @@ import org.joml.Matrix4f;
 import org.joml.Matrix4fc;
 import org.joml.Vector3f;
 
-import java.io.*;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,45 +28,17 @@ public class PD1Manipulator {
         transformationMat = new Matrix4f().identity();
     }
 
-    private void readConstructorBase(InputStream is) throws IOException {
-        var reader = new PD1Reader(is);
+    /**
+     * Creates a PD1 manipulator and loads a PD1 file.
+     *
+     * @param path Path of the PD1 file
+     * @throws IOException If it fails to load the PD1 file
+     */
+    public PD1Manipulator(Path path) throws IOException {
+        var reader = new PD1Reader(path);
         points = reader.getPoints();
 
         transformationMat = new Matrix4f().identity();
-    }
-
-    /**
-     * Creates a PD1 manipulator and loads a PD1.
-     *
-     * @param is input stream to load a PD1 from
-     * @throws IOException if it fails to load
-     */
-    public PD1Manipulator(InputStream is) throws IOException {
-        this.readConstructorBase(is);
-    }
-
-    /**
-     * Creates a PD1 manipulator and loads a PD1.
-     *
-     * @param file file to load a PD1 from
-     * @throws IOException if it fails to load
-     */
-    public PD1Manipulator(File file) throws IOException {
-        try (var bis = new BufferedInputStream(new FileInputStream(file))) {
-            this.readConstructorBase(bis);
-        }
-    }
-
-    /**
-     * Creates a PD1 manipulator and loads a PD1.
-     *
-     * @param filepath filepath to load a PD1 from
-     * @throws IOException if it fails to load
-     */
-    public PD1Manipulator(String filepath) throws IOException {
-        try (var bis = new BufferedInputStream(new FileInputStream(filepath))) {
-            this.readConstructorBase(bis);
-        }
     }
 
     /**
@@ -274,42 +247,14 @@ public class PD1Manipulator {
         return this;
     }
 
-    private void saveAsPD1Base(OutputStream os) throws IOException {
+    /**
+     * Saves the point data in a PD1 file.
+     *
+     * @param path Path of the PD1 file
+     * @throws IOException If it fails to write to the file
+     */
+    public void saveAsPD1(Path path) throws IOException {
         var writer = new PD1Writer();
-        writer.write(os, points);
-    }
-
-    /**
-     * Saves the points as a PD1.
-     *
-     * @param os output stream to write the points to
-     * @throws IOException if it fails to output
-     */
-    public void saveAsPD1(OutputStream os) throws IOException {
-        this.saveAsPD1Base(os);
-    }
-
-    /**
-     * Saves the points as a PD1.
-     *
-     * @param file file to write the points to
-     * @throws IOException if it fails to output
-     */
-    public void saveAsPD1(File file) throws IOException {
-        try (var bos = new BufferedOutputStream(new FileOutputStream(file))) {
-            this.saveAsPD1Base(bos);
-        }
-    }
-
-    /**
-     * Saves the points as a PD1.
-     *
-     * @param filepath filepath to write the points to
-     * @throws IOException if it fails to output
-     */
-    public void saveAsPD1(String filepath) throws IOException {
-        try (var bos = new BufferedOutputStream(new FileOutputStream(filepath))) {
-            this.saveAsPD1Base(bos);
-        }
+        writer.write(path, points);
     }
 }

--- a/jxm-pd1/src/main/java/com/github/dabasan/jxm/pd1/PD1Reader.java
+++ b/jxm-pd1/src/main/java/com/github/dabasan/jxm/pd1/PD1Reader.java
@@ -1,7 +1,8 @@
 package com.github.dabasan.jxm.pd1;
 
 import java.io.IOException;
-import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -16,11 +17,11 @@ import static com.github.dabasan.jxm.bintools.ByteFunctions.getUnsignedShortFrom
 class PD1Reader {
     private final List<PD1Point> points;
 
-    public PD1Reader(InputStream is) throws IOException {
+    public PD1Reader(Path path) throws IOException {
         points = new ArrayList<>();
 
-        //Read all bytes from a stream
-        byte[] bin = is.readAllBytes();
+        //Read all bytes
+        byte[] bin = Files.readAllBytes(path);
 
         int pos = 0;
 

--- a/jxm-pd1/src/main/java/com/github/dabasan/jxm/pd1/PD1Writer.java
+++ b/jxm-pd1/src/main/java/com/github/dabasan/jxm/pd1/PD1Writer.java
@@ -1,9 +1,11 @@
 package com.github.dabasan.jxm.pd1;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.joml.Vector3fc;
 
 import java.io.IOException;
-import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -16,7 +18,7 @@ import static com.github.dabasan.jxm.bintools.ByteFunctions.addUnsignedShortToBi
  * @author maeda6uiui
  */
 class PD1Writer {
-    public void write(OutputStream os, List<PD1Point> points) throws IOException {
+    public void write(Path path, List<PD1Point> points) throws IOException {
         List<Byte> bin = new ArrayList<>();
 
         //Number of points
@@ -44,8 +46,8 @@ class PD1Writer {
             }
         }
 
-        for (byte b : bin) {
-            os.write(b);
-        }
+        Byte[] boxedBytes = bin.toArray(Byte[]::new);
+        byte[] byteArray = ArrayUtils.toPrimitive(boxedBytes);
+        Files.write(path, byteArray);
     }
 }

--- a/jxm-pd1/src/main/java/module-info.java
+++ b/jxm-pd1/src/main/java/module-info.java
@@ -4,4 +4,5 @@ module com.github.dabasan.jxm.pd1 {
     requires transitive org.joml;
     requires transitive org.slf4j;
     requires com.github.dabasan.jxm.bintools;
+    requires org.apache.commons.lang3;
 }

--- a/jxm-pd1/src/test/java/com/github/dabasan/jxm/pd1/PD1ManipulatorTest.java
+++ b/jxm-pd1/src/test/java/com/github/dabasan/jxm/pd1/PD1ManipulatorTest.java
@@ -27,7 +27,7 @@ public class PD1ManipulatorTest {
     @BeforeAll
     public void loadPD1() {
         assertDoesNotThrow(() -> {
-            manipulator = new PD1Manipulator(Paths.get(TARGET_DIR, "point.pd1").toString());
+            manipulator = new PD1Manipulator(Paths.get(TARGET_DIR, "point.pd1"));
         });
 
         origPoints = new ArrayList<>();
@@ -62,9 +62,7 @@ public class PD1ManipulatorTest {
                 .rotate((float) Math.PI / 4.0f, 0.0f, 0.0f, 1.0f)
                 .scale(1.0f, 2.0f, 1.0f);
         manipulator.transform(mat).applyTransformation();
-
-        var saveFilepath = Paths.get(TARGET_DIR, "transform.pd1").toString();
-        assertDoesNotThrow(() -> manipulator.saveAsPD1(saveFilepath));
+        assertDoesNotThrow(() -> manipulator.save(Paths.get(TARGET_DIR, "transform.pd1")));
     }
 
     @Test
@@ -73,45 +71,35 @@ public class PD1ManipulatorTest {
         float amountY = 50.0f;
         float amountZ = 50.0f;
         manipulator.translate(amountX, amountY, amountZ).applyTransformation();
-
-        var saveFilepath = Paths.get(TARGET_DIR, "translate.pd1").toString();
-        assertDoesNotThrow(() -> manipulator.saveAsPD1(saveFilepath));
+        assertDoesNotThrow(() -> manipulator.save(Paths.get(TARGET_DIR, "translate.pd1")));
     }
 
     @Test
     public void rotX() {
         float amount = (float) Math.PI / 4.0f;
         manipulator.rotX(amount).applyTransformation();
-
-        var saveFilepath = Paths.get(TARGET_DIR, "rot_x.pd1").toString();
-        assertDoesNotThrow(() -> manipulator.saveAsPD1(saveFilepath));
+        assertDoesNotThrow(() -> manipulator.save(Paths.get(TARGET_DIR, "rot_x.pd1")));
     }
 
     @Test
     public void rotY() {
         float amount = (float) Math.PI / 4.0f;
         manipulator.rotY(amount).applyTransformation();
-
-        var saveFilepath = Paths.get(TARGET_DIR, "rot_y.pd1").toString();
-        assertDoesNotThrow(() -> manipulator.saveAsPD1(saveFilepath));
+        assertDoesNotThrow(() -> manipulator.save(Paths.get(TARGET_DIR, "rot_y.pd1")));
     }
 
     @Test
     public void rotZ() {
         float amount = (float) Math.PI / 4.0f;
         manipulator.rotZ(amount).applyTransformation();
-
-        var saveFilepath = Paths.get(TARGET_DIR, "rot_z.pd1").toString();
-        assertDoesNotThrow(() -> manipulator.saveAsPD1(saveFilepath));
+        assertDoesNotThrow(() -> manipulator.save(Paths.get(TARGET_DIR, "rot_z.pd1")));
     }
 
     @Test
     public void rot() {
         float amount = (float) Math.PI / 4.0f;
         manipulator.rot(amount, 1.0f, 1.0f, 1.0f).applyTransformation();
-
-        var saveFilepath = Paths.get(TARGET_DIR, "rot.pd1").toString();
-        assertDoesNotThrow(() -> manipulator.saveAsPD1(saveFilepath));
+        assertDoesNotThrow(() -> manipulator.save(Paths.get(TARGET_DIR, "rot.pd1")));
     }
 
     @Test
@@ -120,25 +108,20 @@ public class PD1ManipulatorTest {
         float scaleY = 2.0f;
         float scaleZ = 2.0f;
         manipulator.rescale(scaleX, scaleY, scaleZ).applyTransformation();
-
-        var saveFilepath = Paths.get(TARGET_DIR, "rescale.pd1").toString();
-        assertDoesNotThrow(() -> manipulator.saveAsPD1(saveFilepath));
+        assertDoesNotThrow(() -> manipulator.save(Paths.get(TARGET_DIR, "rescale.pd1")));
     }
 
     @Test
     public void invertZ() {
         manipulator.invertZ();
-
-        var saveFilepath = Paths.get(TARGET_DIR, "invert_z.pd1").toString();
-        assertDoesNotThrow(() -> manipulator.saveAsPD1(saveFilepath));
+        assertDoesNotThrow(() -> manipulator.save(Paths.get(TARGET_DIR, "invert_z.pd1")));
     }
 
     @Test
     public void testUpdate() {
         List<PD1Point> tmpPoints;
         try {
-            var tmpFilepath = Paths.get(TARGET_DIR, "point_2.pd1").toString();
-            var tmpManipulator = new PD1Manipulator(tmpFilepath);
+            var tmpManipulator = new PD1Manipulator(Paths.get(TARGET_DIR, "point_2.pd1"));
             tmpPoints = tmpManipulator.getPoints();
         } catch (IOException e) {
             fail(e);
@@ -153,8 +136,6 @@ public class PD1ManipulatorTest {
     public void rotateDirection() {
         float amount = (float) Math.PI / 4.0f;
         manipulator.rotateDirection(amount);
-
-        var saveFilepath = Paths.get(TARGET_DIR, "rotate_direction.pd1").toString();
-        assertDoesNotThrow(() -> manipulator.saveAsPD1(saveFilepath));
+        assertDoesNotThrow(() -> manipulator.save(Paths.get(TARGET_DIR, "rotate_direction.pd1")));
     }
 }

--- a/jxm-properties/pom.xml
+++ b/jxm-properties/pom.xml
@@ -47,5 +47,11 @@
             <artifactId>jxm-bintools</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.19.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/character/xcs/XCSManipulator.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/character/xcs/XCSManipulator.java
@@ -66,7 +66,7 @@ public class XCSManipulator {
      * @param path Path of the XCS file
      * @throws IOException if it fails to write to the file
      */
-    public void saveAsXCS(Path path) throws IOException {
+    public void save(Path path) throws IOException {
         var writer = new XCSWriter();
         writer.write(path, characters);
     }

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/character/xcs/XCSManipulator.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/character/xcs/XCSManipulator.java
@@ -4,7 +4,8 @@ import com.github.dabasan.jxm.properties.character.JXMCharacter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.IOException;
+import java.nio.file.Path;
 
 /**
  * XCS manipulator
@@ -24,43 +25,15 @@ public class XCSManipulator {
         characters = new JXMCharacter[NUM_CHARACTERS];
     }
 
-    private void readConstructorBase(InputStream is) throws IOException {
-        var reader = new XCSReader(is, NUM_CHARACTERS);
+    /**
+     * Creates a XCS manipulator and loads a XCS file.
+     *
+     * @param path Path of the XCS file
+     * @throws IOException If it fails to load the file
+     */
+    public XCSManipulator(Path path) throws IOException {
+        var reader = new XCSReader(path, NUM_CHARACTERS);
         characters = reader.getCharacterData();
-    }
-
-    /**
-     * Creates a XCS manipulator and loads a XCS.
-     *
-     * @param is input stream to load a XCS from
-     * @throws IOException if it fails to load
-     */
-    public XCSManipulator(InputStream is) throws IOException {
-        this.readConstructorBase(is);
-    }
-
-    /**
-     * Creates a XCS manipulator and loads a XCS.
-     *
-     * @param file file to load a XCS from
-     * @throws IOException if it fails to load
-     */
-    public XCSManipulator(File file) throws IOException {
-        try (var bis = new BufferedInputStream(new FileInputStream(file))) {
-            this.readConstructorBase(bis);
-        }
-    }
-
-    /**
-     * Creates a XCS manipulator and loads a XCS.
-     *
-     * @param filepath filepath to load a XCS from
-     * @throws IOException if it fails to load
-     */
-    public XCSManipulator(String filepath) throws IOException {
-        try (var bis = new BufferedInputStream(new FileInputStream(filepath))) {
-            this.readConstructorBase(bis);
-        }
     }
 
     /**
@@ -87,42 +60,14 @@ public class XCSManipulator {
         this.characters = characters;
     }
 
-    private void saveAsXCSBase(OutputStream os) throws IOException {
+    /**
+     * Saves the character data in a XCS file.
+     *
+     * @param path Path of the XCS file
+     * @throws IOException if it fails to write to the file
+     */
+    public void saveAsXCS(Path path) throws IOException {
         var writer = new XCSWriter();
-        writer.write(os, characters);
-    }
-
-    /**
-     * Saves character data as a XCS.
-     *
-     * @param os output stream to write characters to
-     * @throws IOException if it fails to output
-     */
-    public void saveAsXCS(OutputStream os) throws IOException {
-        this.saveAsXCSBase(os);
-    }
-
-    /**
-     * Saves character data as a XCS.
-     *
-     * @param file file to write characters to
-     * @throws IOException if it fails to output
-     */
-    public void saveAsXCS(File file) throws IOException {
-        try (var bos = new BufferedOutputStream(new FileOutputStream(file))) {
-            this.saveAsXCSBase(bos);
-        }
-    }
-
-    /**
-     * Saves character data as a XCS.
-     *
-     * @param filepath filepath to write characters to
-     * @throws IOException if it fails to output
-     */
-    public void saveAsXCS(String filepath) throws IOException {
-        try (var bos = new BufferedOutputStream(new FileOutputStream(filepath))) {
-            this.saveAsXCSBase(bos);
-        }
+        writer.write(path, characters);
     }
 }

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/character/xcs/XCSReader.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/character/xcs/XCSReader.java
@@ -3,7 +3,8 @@ package com.github.dabasan.jxm.properties.character.xcs;
 import com.github.dabasan.jxm.properties.character.*;
 
 import java.io.IOException;
-import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static com.github.dabasan.jxm.bintools.ByteFunctions.getShortFromBinLE;
 import static com.github.dabasan.jxm.bintools.ByteFunctions.getUnsignedShortFromBinLE;
@@ -18,10 +19,10 @@ class XCSReader {
 
     private int pos;
 
-    public XCSReader(InputStream is, int numCharacters) throws IOException {
+    public XCSReader(Path path, int numCharacters) throws IOException {
         characters = new JXMCharacter[numCharacters];
 
-        byte[] bin = is.readAllBytes();
+        byte[] bin = Files.readAllBytes(path);
         pos = 0x0000000C;
 
         for (int i = 0; i < numCharacters; i++) {

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/character/xcs/XCSWriter.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/character/xcs/XCSWriter.java
@@ -3,9 +3,11 @@ package com.github.dabasan.jxm.properties.character.xcs;
 import com.github.dabasan.jxm.properties.character.CharacterBinEnumConverter;
 import com.github.dabasan.jxm.properties.character.CharacterModelType;
 import com.github.dabasan.jxm.properties.character.JXMCharacter;
+import org.apache.commons.lang3.ArrayUtils;
 
 import java.io.IOException;
-import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 
 import static com.github.dabasan.jxm.bintools.ByteFunctions.addShortToBinLE;
@@ -17,7 +19,7 @@ import static com.github.dabasan.jxm.bintools.ByteFunctions.addUnsignedShortToBi
  * @author maeda6uiui
  */
 class XCSWriter {
-    public void write(OutputStream os, JXMCharacter[] characters) throws IOException {
+    public void write(Path path, JXMCharacter[] characters) throws IOException {
         var bin = new ArrayList<Byte>();
 
         bin.add((byte) 0x58);//X
@@ -49,8 +51,8 @@ class XCSWriter {
             addShortToBinLE(bin, (short) character.type.ordinal());
         }
 
-        for (byte b : bin) {
-            os.write(b);
-        }
+        Byte[] boxedBytes = bin.toArray(Byte[]::new);
+        byte[] byteArray = ArrayUtils.toPrimitive(boxedBytes);
+        Files.write(path, byteArray);
     }
 }

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/config/ConfigManipulator.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/config/ConfigManipulator.java
@@ -3,7 +3,8 @@ package com.github.dabasan.jxm.properties.config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.IOException;
+import java.nio.file.Path;
 
 /**
  * Config manipulator
@@ -22,43 +23,15 @@ public class ConfigManipulator {
         config = new JXMConfig();
     }
 
-    private void readConstructorBase(InputStream is) throws IOException {
-        var reader = new ConfigReader(is);
+    /**
+     * Creates a config manipulator and loads a config file.
+     *
+     * @param path Path of the config file
+     * @throws IOException If it fails to load the file
+     */
+    public ConfigManipulator(Path path) throws IOException {
+        var reader = new ConfigReader(path);
         config = reader.getConfig();
-    }
-
-    /**
-     * Creates a config manipulator and loads config.
-     *
-     * @param is input stream to load config from
-     * @throws IOException if it fails to load
-     */
-    public ConfigManipulator(InputStream is) throws IOException {
-        this.readConstructorBase(is);
-    }
-
-    /**
-     * Creates a config manipulator and loads config.
-     *
-     * @param file file to load config from
-     * @throws IOException if it fails to load
-     */
-    public ConfigManipulator(File file) throws IOException {
-        try (var bis = new BufferedInputStream(new FileInputStream(file))) {
-            this.readConstructorBase(bis);
-        }
-    }
-
-    /**
-     * Creates a config manipulator and loads config.
-     *
-     * @param filepath filepath to load config from
-     * @throws IOException if it fails to load
-     */
-    public ConfigManipulator(String filepath) throws IOException {
-        try (var bis = new BufferedInputStream(new FileInputStream(filepath))) {
-            this.readConstructorBase(bis);
-        }
     }
 
     /**
@@ -79,42 +52,14 @@ public class ConfigManipulator {
         this.config = config;
     }
 
-    private void saveAsDATBase(OutputStream os) throws IOException {
+    /**
+     * Saves the config data in a file.
+     *
+     * @param path Path of the file
+     * @throws IOException If it fails to write to the file
+     */
+    public void save(Path path) throws IOException {
         var writer = new ConfigWriter();
-        writer.write(os, config);
-    }
-
-    /**
-     * Saves config as a DAT.
-     *
-     * @param os output stream to write the config to
-     * @throws IOException if it fails to output
-     */
-    public void saveAsDAT(OutputStream os) throws IOException {
-        this.saveAsDATBase(os);
-    }
-
-    /**
-     * Saves config as a DAT.
-     *
-     * @param file file to write the config to
-     * @throws IOException if it fails to output
-     */
-    public void saveAsDAT(File file) throws IOException {
-        try (var bos = new BufferedOutputStream(new FileOutputStream(file))) {
-            this.saveAsDATBase(bos);
-        }
-    }
-
-    /**
-     * Saves config as a DAT.
-     *
-     * @param filepath filepath to write the config to
-     * @throws IOException if it fails to output
-     */
-    public void saveAsDAT(String filepath) throws IOException {
-        try (var bos = new BufferedOutputStream(new FileOutputStream(filepath))) {
-            this.saveAsDATBase(bos);
-        }
+        writer.write(path, config);
     }
 }

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/config/ConfigReader.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/config/ConfigReader.java
@@ -1,7 +1,8 @@
 package com.github.dabasan.jxm.properties.config;
 
 import java.io.IOException;
-import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.function.Function;
 
 /**
@@ -12,11 +13,11 @@ import java.util.function.Function;
 class ConfigReader {
     private final JXMConfig config;
 
-    public ConfigReader(InputStream is) throws IOException {
+    public ConfigReader(Path path) throws IOException {
         config = new JXMConfig();
 
-        //Read all bytes from a stream
-        byte[] bin = is.readAllBytes();
+        //Read all bytes
+        byte[] bin = Files.readAllBytes(path);
 
         var keyCodes = KeyCode.values();
 

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/config/ConfigWriter.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/config/ConfigWriter.java
@@ -1,7 +1,10 @@
 package com.github.dabasan.jxm.properties.config;
 
+import org.apache.commons.lang3.ArrayUtils;
+
 import java.io.IOException;
-import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -13,7 +16,7 @@ import java.util.function.Function;
  * @author maeda6uiui
  */
 class ConfigWriter {
-    public void write(OutputStream os, JXMConfig config) throws IOException {
+    public void write(Path path, JXMConfig config) throws IOException {
         var bin = new ArrayList<Byte>();
 
         bin.add((byte) config.turnUp.ordinal());
@@ -53,9 +56,9 @@ class ConfigWriter {
         bin.add(booleanToByte.apply(config.anotherGunsight));
         this.addNameToBin(bin, config.name);
 
-        for (byte b : bin) {
-            os.write(b);
-        }
+        Byte[] boxedBytes = bin.toArray(Byte[]::new);
+        byte[] byteArray = ArrayUtils.toPrimitive(boxedBytes);
+        Files.write(path, byteArray);
     }
 
     private void addNameToBin(List<Byte> bin, String name) {

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/ids/IDSManipulator.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/ids/IDSManipulator.java
@@ -4,7 +4,8 @@ import com.github.dabasan.jxm.properties.weapon.JXMWeapon;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.IOException;
+import java.nio.file.Path;
 
 /**
  * IDS manipulator
@@ -23,43 +24,15 @@ public class IDSManipulator {
         weapon = new JXMWeapon();
     }
 
-    private void readConstructorBase(InputStream is) throws IOException {
-        var reader = new IDSReader(is);
+    /**
+     * Creates an IDS manipulator and loads an IDS file.
+     *
+     * @param path Path of the IDS file
+     * @throws IOException If it fails to load the file
+     */
+    public IDSManipulator(Path path) throws IOException {
+        var reader = new IDSReader(path);
         weapon = reader.getWeaponData();
-    }
-
-    /**
-     * Creates an IDS manipulator.
-     *
-     * @param is input stream to load an IDS from
-     * @throws IOException if it fails to load
-     */
-    public IDSManipulator(InputStream is) throws IOException {
-        this.readConstructorBase(is);
-    }
-
-    /**
-     * Creates an IDS manipulator.
-     *
-     * @param file file to load an IDS from
-     * @throws IOException if it fails to load
-     */
-    public IDSManipulator(File file) throws IOException {
-        try (var bis = new BufferedInputStream(new FileInputStream(file))) {
-            this.readConstructorBase(bis);
-        }
-    }
-
-    /**
-     * Creates an IDS manipulator.
-     *
-     * @param filepath filepath to load an IDS from
-     * @throws IOException if it fails to load
-     */
-    public IDSManipulator(String filepath) throws IOException {
-        try (var bis = new BufferedInputStream(new FileInputStream(filepath))) {
-            this.readConstructorBase(bis);
-        }
     }
 
     /**
@@ -80,42 +53,14 @@ public class IDSManipulator {
         this.weapon = weapon;
     }
 
-    private void innerSaveAsIDS(OutputStream os) throws IOException {
+    /**
+     * Saves the weapon data in an IDS file.
+     *
+     * @param path Path of the IDS file
+     * @throws IOException if it fails to write to the file
+     */
+    public void save(Path path) throws IOException {
         var writer = new IDSWriter();
-        writer.write(os, weapon);
-    }
-
-    /**
-     * Saves weapon data as an IDS.
-     *
-     * @param os output stream to write the weapon data to
-     * @throws IOException if it fails to output
-     */
-    public void saveAsIDS(OutputStream os) throws IOException {
-        this.innerSaveAsIDS(os);
-    }
-
-    /**
-     * Saves weapon data as an IDS.
-     *
-     * @param file file to write the weapon data to
-     * @throws IOException if it fails to output
-     */
-    public void saveAsIDS(File file) throws IOException {
-        try (var bos = new BufferedOutputStream(new FileOutputStream(file))) {
-            this.innerSaveAsIDS(bos);
-        }
-    }
-
-    /**
-     * Saves weapon data as an IDS.
-     *
-     * @param filepath filepath to write the weapon data to
-     * @throws IOException if it fails to output
-     */
-    public void saveAsIDS(String filepath) throws IOException {
-        try (var bos = new BufferedOutputStream(new FileOutputStream(filepath))) {
-            this.innerSaveAsIDS(bos);
-        }
+        writer.write(path, weapon);
     }
 }

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/ids/IDSReader.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/ids/IDSReader.java
@@ -3,7 +3,8 @@ package com.github.dabasan.jxm.properties.weapon.ids;
 import com.github.dabasan.jxm.properties.weapon.*;
 
 import java.io.IOException;
-import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 
 import static com.github.dabasan.jxm.bintools.ByteFunctions.getShortFromBinLE;
@@ -17,10 +18,10 @@ class IDSReader {
     private final JXMWeapon weapon;
     private int pos;
 
-    public IDSReader(InputStream is) throws IOException {
+    public IDSReader(Path path) throws IOException {
         weapon = new JXMWeapon();
 
-        byte[] bin = is.readAllBytes();
+        byte[] bin = Files.readAllBytes(path);
         pos = 0x0000000A;
 
         weapon.attackPower = this.getShortAndIncrementPos(bin);

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/ids/IDSWriter.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/ids/IDSWriter.java
@@ -1,9 +1,11 @@
 package com.github.dabasan.jxm.properties.weapon.ids;
 
 import com.github.dabasan.jxm.properties.weapon.*;
+import org.apache.commons.lang3.ArrayUtils;
 
 import java.io.IOException;
-import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -15,7 +17,7 @@ import static com.github.dabasan.jxm.bintools.ByteFunctions.addShortToBinLE;
  * @author maeda6uiui
  */
 class IDSWriter {
-    public void write(OutputStream os, JXMWeapon weapon) throws IOException {
+    public void write(Path path, JXMWeapon weapon) throws IOException {
         var bin = new ArrayList<Byte>();
 
         bin.add((byte) 0x49);//I
@@ -83,9 +85,9 @@ class IDSWriter {
 
         this.addNameToBin(bin, weapon.name);
 
-        for (byte b : bin) {
-            os.write(b);
-        }
+        Byte[] boxedBytes = bin.toArray(Byte[]::new);
+        byte[] byteArray = ArrayUtils.toPrimitive(boxedBytes);
+        Files.write(path, byteArray);
     }
 
     private void addNameToBin(List<Byte> bin, String name) {

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/xgs/XGSManipulator.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/xgs/XGSManipulator.java
@@ -4,7 +4,8 @@ import com.github.dabasan.jxm.properties.weapon.JXMWeapon;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.IOException;
+import java.nio.file.Path;
 
 /**
  * XGS manipulator
@@ -24,43 +25,15 @@ public class XGSManipulator {
         weapons = new JXMWeapon[NUM_WEAPONS];
     }
 
-    private void readConstructorBase(InputStream is) throws IOException {
-        var reader = new XGSReader(is, NUM_WEAPONS);
+    /**
+     * Creates a XGS manipulator and loads a XGS file.
+     *
+     * @param path Path of the XGS file
+     * @throws IOException If it fails to load the file
+     */
+    public XGSManipulator(Path path) throws IOException {
+        var reader = new XGSReader(path, NUM_WEAPONS);
         weapons = reader.getWeaponData();
-    }
-
-    /**
-     * Creates a XGS manipulator and loads a XGS.
-     *
-     * @param is input stream to load a XGS from
-     * @throws IOException if it fails to load
-     */
-    public XGSManipulator(InputStream is) throws IOException {
-        this.readConstructorBase(is);
-    }
-
-    /**
-     * Creates a XGS manipulator and loads a XGS.
-     *
-     * @param file file to load a XGS from
-     * @throws IOException if it fails to load
-     */
-    public XGSManipulator(File file) throws IOException {
-        try (var bis = new BufferedInputStream(new FileInputStream(file))) {
-            this.readConstructorBase(bis);
-        }
-    }
-
-    /**
-     * Creates a XGS manipulator and loads a XGS.
-     *
-     * @param filepath filepath to load a XGS from
-     * @throws IOException if it fails to load
-     */
-    public XGSManipulator(String filepath) throws IOException {
-        try (var bis = new BufferedInputStream(new FileInputStream(filepath))) {
-            this.readConstructorBase(bis);
-        }
     }
 
     /**
@@ -86,42 +59,14 @@ public class XGSManipulator {
         this.weapons = weapons;
     }
 
-    private void saveAsXGSBase(OutputStream os) throws IOException {
+    /**
+     * Saves the weapon data in a XGS file.
+     *
+     * @param path Path of the XGS file
+     * @throws IOException if it fails to write to the file
+     */
+    public void save(Path path) throws IOException {
         var writer = new XGSWriter();
-        writer.write(os, weapons);
-    }
-
-    /**
-     * Saves weapon data as a XGS.
-     *
-     * @param os output stream to write the weapon data to
-     * @throws IOException if it fails to output
-     */
-    public void saveAsXGS(OutputStream os) throws IOException {
-        this.saveAsXGSBase(os);
-    }
-
-    /**
-     * Saves weapon data as a XGS.
-     *
-     * @param file file to write the weapon data to
-     * @throws IOException if it fails to output
-     */
-    public void saveAsXGS(File file) throws IOException {
-        try (var bos = new BufferedOutputStream(new FileOutputStream(file))) {
-            this.saveAsXGSBase(bos);
-        }
-    }
-
-    /**
-     * Saves weapon data as a XGS.
-     *
-     * @param filepath filepath to write the weapon data to
-     * @throws IOException if it fails to output
-     */
-    public void saveAsXGS(String filepath) throws IOException {
-        try (var bos = new BufferedOutputStream(new FileOutputStream(filepath))) {
-            this.saveAsXGSBase(bos);
-        }
+        writer.write(path, weapons);
     }
 }

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/xgs/XGSReader.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/xgs/XGSReader.java
@@ -3,7 +3,8 @@ package com.github.dabasan.jxm.properties.weapon.xgs;
 import com.github.dabasan.jxm.properties.weapon.*;
 
 import java.io.IOException;
-import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 
 import static com.github.dabasan.jxm.bintools.ByteFunctions.getShortFromBinLE;
@@ -17,10 +18,10 @@ class XGSReader {
     private final JXMWeapon[] weapons;
     private int pos;
 
-    public XGSReader(InputStream is, int numWeapons) throws IOException {
+    public XGSReader(Path path, int numWeapons) throws IOException {
         weapons = new JXMWeapon[numWeapons];
 
-        byte[] bin = is.readAllBytes();
+        byte[] bin = Files.readAllBytes(path);
         pos = 0x0000000E;
 
         for (int i = 0; i < numWeapons; i++) {

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/xgs/XGSWriter.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/weapon/xgs/XGSWriter.java
@@ -1,9 +1,11 @@
 package com.github.dabasan.jxm.properties.weapon.xgs;
 
 import com.github.dabasan.jxm.properties.weapon.*;
+import org.apache.commons.lang3.ArrayUtils;
 
 import java.io.IOException;
-import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -15,7 +17,7 @@ import static com.github.dabasan.jxm.bintools.ByteFunctions.addShortToBinLE;
  * @author maeda6uiui
  */
 class XGSWriter {
-    public void write(OutputStream os, JXMWeapon[] weapons) throws IOException {
+    public void write(Path path, JXMWeapon[] weapons) throws IOException {
         var bin = new ArrayList<Byte>();
 
         bin.add((byte) 0x58);//X
@@ -97,9 +99,9 @@ class XGSWriter {
             bin.add((byte) 0x00);
         }
 
-        for (byte b : bin) {
-            os.write(b);
-        }
+        Byte[] boxedBytes = bin.toArray(Byte[]::new);
+        byte[] byteArray = ArrayUtils.toPrimitive(boxedBytes);
+        Files.write(path, byteArray);
     }
 
     private void addNameToBin(List<Byte> bin, String name) {

--- a/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/xops/EXEManipulator.java
+++ b/jxm-properties/src/main/java/com/github/dabasan/jxm/properties/xops/EXEManipulator.java
@@ -232,7 +232,7 @@ public class EXEManipulator {
             Files.write(pathBackup, bin);
         }
 
-        //Detect the version of XOPS
+        //Update weapon and character data
         XOPSVersion version = XOPSFunctions.getXOPSVersion(bin);
         int weaponDataStartPos = this.getWeaponDataStartPos(version);
         int weaponNameStartPos = this.getWeaponNameStartPos(version);

--- a/jxm-properties/src/main/java/module-info.java
+++ b/jxm-properties/src/main/java/module-info.java
@@ -13,4 +13,5 @@ module com.github.dabasan.jxm.properties {
 
     requires transitive org.slf4j;
     requires com.github.dabasan.jxm.bintools;
+    requires org.apache.commons.lang3;
 }

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/CharacterCodeGeneratorTest.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/CharacterCodeGeneratorTest.java
@@ -29,7 +29,7 @@ public class CharacterCodeGeneratorTest {
     @BeforeAll
     public void loadCharacters() {
         assertDoesNotThrow(() -> {
-            manipulator = new XCSManipulator("./TestData/Character/characters.xcs");
+            manipulator = new XCSManipulator(Paths.get("./TestData/Character/characters.xcs"));
             expectedLines = Files.readAllLines(Paths.get("./TestData/Character/character_code.txt"));
         });
     }

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/CharacterCodeParserTest.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/CharacterCodeParserTest.java
@@ -30,7 +30,7 @@ public class CharacterCodeParserTest {
     @BeforeAll
     public void loadCharacters() {
         assertDoesNotThrow(() -> {
-            var manipulator = new XCSManipulator("./TestData/Character/characters.xcs");
+            var manipulator = new XCSManipulator(Paths.get("./TestData/Character/characters.xcs"));
             expectedCharacters = manipulator.getCharacters();
 
             codeLines = Files.readAllLines(

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/ConfigManipulatorTest.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/ConfigManipulatorTest.java
@@ -76,7 +76,7 @@ public class ConfigManipulatorTest {
     }
 
     @Test
-    public void saveAsDAT() {
+    public void testSave() {
         var srcPath = Paths.get(TARGET_DIR, "config.dat");
         var outputPath = Paths.get(TARGET_DIR, "config_2.dat");
         assertDoesNotThrow(() -> manipulator.save(outputPath));

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/ConfigManipulatorTest.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/ConfigManipulatorTest.java
@@ -26,7 +26,7 @@ public class ConfigManipulatorTest {
     @BeforeAll
     public void loadConfig() {
         assertDoesNotThrow(() -> {
-            manipulator = new ConfigManipulator(Paths.get(TARGET_DIR, "config.dat").toString());
+            manipulator = new ConfigManipulator(Paths.get(TARGET_DIR, "config.dat"));
         });
     }
 
@@ -77,12 +77,12 @@ public class ConfigManipulatorTest {
 
     @Test
     public void saveAsDAT() {
-        var srcFilepath = Paths.get(TARGET_DIR, "config.dat").toString();
-        var outputFilepath = Paths.get(TARGET_DIR, "config_2.dat").toString();
-        assertDoesNotThrow(() -> manipulator.saveAsDAT(outputFilepath));
+        var srcPath = Paths.get(TARGET_DIR, "config.dat");
+        var outputPath = Paths.get(TARGET_DIR, "config_2.dat");
+        assertDoesNotThrow(() -> manipulator.save(outputPath));
 
-        String srcFileHash = TestUtils.getFileHash(srcFilepath);
-        String outputFileHash = TestUtils.getFileHash(outputFilepath);
+        String srcFileHash = TestUtils.getFileHash(srcPath);
+        String outputFileHash = TestUtils.getFileHash(outputPath);
         assertEquals(srcFileHash, outputFileHash);
     }
 }

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/EXEManipulatorTest.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/EXEManipulatorTest.java
@@ -60,14 +60,14 @@ public class EXEManipulatorTest {
 
             manipulators = new HashMap<>();
             for (var srcFilename : srcFilenames) {
-                var manipulator = new EXEManipulator(Paths.get(TARGET_DIR, srcFilename).toString());
+                var manipulator = new EXEManipulator(Paths.get(TARGET_DIR, srcFilename));
                 manipulators.put(srcFilename, manipulator);
             }
 
-            var xgsManipulator = new XGSManipulator(Paths.get(TARGET_DIR, "Expected", "weapons.xgs").toString());
+            var xgsManipulator = new XGSManipulator(Paths.get(TARGET_DIR, "Expected", "weapons.xgs"));
             expectedWeapons = xgsManipulator.getWeapons();
 
-            var xcsManipulator = new XCSManipulator(Paths.get(TARGET_DIR, "Expected", "characters.xcs").toString());
+            var xcsManipulator = new XCSManipulator(Paths.get(TARGET_DIR, "Expected", "characters.xcs"));
             expectedCharacters = xcsManipulator.getCharacters();
         });
     }
@@ -132,19 +132,19 @@ public class EXEManipulatorTest {
     @Test
     public void write() {
         manipulators.forEach((filename, manipulator) -> {
-            String exeFilepath = Paths.get(TARGET_DIR, filename).toString();
-            String backupFilepath = Paths.get(TARGET_DIR, filename + ".backup").toString();
-            assertDoesNotThrow(() -> manipulator.write(exeFilepath, backupFilepath));
+            Path exePath = Paths.get(TARGET_DIR, filename);
+            Path backupPath = Paths.get(TARGET_DIR, filename + ".backup");
+            assertDoesNotThrow(() -> manipulator.write(exePath, backupPath));
         });
 
         manipulators.keySet().forEach(filename -> {
-            String targetFilepath = Paths.get(TARGET_DIR, filename).toString();
-            String backupFilepath = Paths.get(TARGET_DIR, filename + ".backup").toString();
-            String originalFilepath = Paths.get(TARGET_DIR, "Original", filename).toString();
+            Path targetPath = Paths.get(TARGET_DIR, filename);
+            Path backupPath = Paths.get(TARGET_DIR, filename + ".backup");
+            Path originalPath = Paths.get(TARGET_DIR, "Original", filename);
 
-            String targetFileHash = TestUtils.getFileHash(targetFilepath);
-            String backupFileHash = TestUtils.getFileHash(backupFilepath);
-            String originalFileHash = TestUtils.getFileHash(originalFilepath);
+            String targetFileHash = TestUtils.getFileHash(targetPath);
+            String backupFileHash = TestUtils.getFileHash(backupPath);
+            String originalFileHash = TestUtils.getFileHash(originalPath);
 
             assertAll(
                     () -> assertEquals(targetFileHash, backupFileHash),

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/EXEManipulatorTest.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/EXEManipulatorTest.java
@@ -130,7 +130,7 @@ public class EXEManipulatorTest {
     }
 
     @Test
-    public void write() {
+    public void testWrite() {
         manipulators.forEach((filename, manipulator) -> {
             Path exePath = Paths.get(TARGET_DIR, filename);
             Path backupPath = Paths.get(TARGET_DIR, filename + ".backup");

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/IDSManipulatorTest.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/IDSManipulatorTest.java
@@ -52,7 +52,7 @@ public class IDSManipulatorTest {
     }
 
     @Test
-    public void saveAsIDS() {
+    public void testSave() {
         Path srcPath = Paths.get(TARGET_DIR, "mp5.ids");
         Path savePath = Paths.get(TARGET_DIR, "mp5_2.ids");
         assertDoesNotThrow(() -> manipulator.save(savePath));

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/IDSManipulatorTest.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/IDSManipulatorTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -26,9 +27,9 @@ public class IDSManipulatorTest {
     @BeforeAll
     public void loadWeapon() {
         assertDoesNotThrow(() -> {
-            manipulator = new IDSManipulator(Paths.get(TARGET_DIR, "mp5.ids").toString());
+            manipulator = new IDSManipulator(Paths.get(TARGET_DIR, "mp5.ids"));
 
-            var xgsManipulator = new XGSManipulator(Paths.get(TARGET_DIR, "weapons.xgs").toString());
+            var xgsManipulator = new XGSManipulator(Paths.get(TARGET_DIR, "weapons.xgs"));
             expectedWeapon = xgsManipulator.getWeapons()[1];
         });
     }
@@ -52,12 +53,12 @@ public class IDSManipulatorTest {
 
     @Test
     public void saveAsIDS() {
-        var srcFilepath = Paths.get(TARGET_DIR, "mp5.ids").toString();
-        var saveFilepath = Paths.get(TARGET_DIR, "mp5_2.ids").toString();
-        assertDoesNotThrow(() -> manipulator.saveAsIDS(saveFilepath));
+        Path srcPath = Paths.get(TARGET_DIR, "mp5.ids");
+        Path savePath = Paths.get(TARGET_DIR, "mp5_2.ids");
+        assertDoesNotThrow(() -> manipulator.save(savePath));
 
-        String srcFileHash = TestUtils.getFileHash(srcFilepath);
-        String outputFileHash = TestUtils.getFileHash(saveFilepath);
+        String srcFileHash = TestUtils.getFileHash(srcPath);
+        String outputFileHash = TestUtils.getFileHash(savePath);
         assertEquals(srcFileHash, outputFileHash);
     }
 }

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/TestUtils.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/TestUtils.java
@@ -9,8 +9,9 @@ import com.github.dabasan.jxm.properties.weapon.ScopeMode;
 import com.github.dabasan.jxm.properties.weapon.ShootingStance;
 
 import java.io.BufferedInputStream;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -32,7 +33,7 @@ public class TestUtils {
         random = new Random();
     }
 
-    public static String getFileHash(String filepath) {
+    public static String getFileHash(Path path) {
         MessageDigest md = null;
         try {
             md = MessageDigest.getInstance("MD5");
@@ -41,7 +42,7 @@ public class TestUtils {
         }
 
         byte[] hash = null;
-        try (var dis = new DigestInputStream(new BufferedInputStream(new FileInputStream(filepath)), md)) {
+        try (var dis = new DigestInputStream(new BufferedInputStream(Files.newInputStream(path)), md)) {
             while (dis.read() != -1) {
 
             }

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/WeaponCodeGeneratorTest.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/WeaponCodeGeneratorTest.java
@@ -29,7 +29,7 @@ public class WeaponCodeGeneratorTest {
     @BeforeAll
     public void loadWeapons() {
         assertDoesNotThrow(() -> {
-            manipulator = new XGSManipulator(Paths.get("./TestData/Weapon/weapons.xgs").toString());
+            manipulator = new XGSManipulator(Paths.get("./TestData/Weapon/weapons.xgs"));
             expectedLines = Files.readAllLines(Paths.get("./TestData/Weapon/weapon_code.txt"));
         });
     }

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/WeaponCodeParserTest.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/WeaponCodeParserTest.java
@@ -29,7 +29,7 @@ public class WeaponCodeParserTest {
     @BeforeAll
     public void loadWeapons() {
         assertDoesNotThrow(() -> {
-            var manipulator = new XGSManipulator("./TestData/Weapon/weapons.xgs");
+            var manipulator = new XGSManipulator(Paths.get("./TestData/Weapon/weapons.xgs"));
             expectedWeapons = manipulator.getWeapons();
 
             codeLines = Files.readAllLines(Paths.get("./TestData/Weapon/weapon_code.txt"));

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/XCSManipulatorTest.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/XCSManipulatorTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -25,9 +26,9 @@ public class XCSManipulatorTest {
     @BeforeAll
     public void loadCharacters() {
         assertDoesNotThrow(() -> {
-            manipulator = new XCSManipulator(Paths.get(TARGET_DIR, "characters.xcs").toString());
+            manipulator = new XCSManipulator(Paths.get(TARGET_DIR, "characters.xcs"));
 
-            var exeManipulator = new EXEManipulator(Paths.get(TARGET_DIR, "xops0975t.exe").toString());
+            var exeManipulator = new EXEManipulator(Paths.get(TARGET_DIR, "xops0975t.exe"));
             expectedCharacters = exeManipulator.getCharacters();
         });
     }
@@ -54,12 +55,12 @@ public class XCSManipulatorTest {
 
     @Test
     public void saveAsXCS() {
-        var srcFilepath = Paths.get(TARGET_DIR, "characters.xcs").toString();
-        var outputFilepath = Paths.get(TARGET_DIR, "characters_2.xcs").toString();
-        assertDoesNotThrow(() -> manipulator.saveAsXCS(outputFilepath));
+        Path srcPath = Paths.get(TARGET_DIR, "characters.xcs");
+        Path outputPath = Paths.get(TARGET_DIR, "characters_2.xcs");
+        assertDoesNotThrow(() -> manipulator.saveAsXCS(outputPath));
 
-        String srcFileHash = TestUtils.getFileHash(srcFilepath);
-        String outputFileHash = TestUtils.getFileHash(outputFilepath);
+        String srcFileHash = TestUtils.getFileHash(srcPath);
+        String outputFileHash = TestUtils.getFileHash(outputPath);
         assertEquals(srcFileHash, outputFileHash);
     }
 }

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/XCSManipulatorTest.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/XCSManipulatorTest.java
@@ -57,7 +57,7 @@ public class XCSManipulatorTest {
     public void testSave() {
         Path srcPath = Paths.get(TARGET_DIR, "characters.xcs");
         Path outputPath = Paths.get(TARGET_DIR, "characters_2.xcs");
-        assertDoesNotThrow(() -> manipulator.saveAsXCS(outputPath));
+        assertDoesNotThrow(() -> manipulator.save(outputPath));
 
         String srcFileHash = TestUtils.getFileHash(srcPath);
         String outputFileHash = TestUtils.getFileHash(outputPath);

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/XCSManipulatorTest.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/XCSManipulatorTest.java
@@ -54,7 +54,7 @@ public class XCSManipulatorTest {
     }
 
     @Test
-    public void saveAsXCS() {
+    public void testSave() {
         Path srcPath = Paths.get(TARGET_DIR, "characters.xcs");
         Path outputPath = Paths.get(TARGET_DIR, "characters_2.xcs");
         assertDoesNotThrow(() -> manipulator.saveAsXCS(outputPath));

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/XGSManipulatorTest.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/XGSManipulatorTest.java
@@ -54,7 +54,7 @@ public class XGSManipulatorTest {
     }
 
     @Test
-    public void saveAsXGS() {
+    public void testSave() {
         Path srcPath = Paths.get(TARGET_DIR, "weapons.xgs");
         Path outputPath = Paths.get(TARGET_DIR, "weapons_2.xgs");
         assertDoesNotThrow(() -> manipulator.save(outputPath));

--- a/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/XGSManipulatorTest.java
+++ b/jxm-properties/src/test/java/com/github/dabasan/jxm/properties/XGSManipulatorTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -25,9 +26,9 @@ public class XGSManipulatorTest {
     @BeforeAll
     public void loadWeapons() {
         assertDoesNotThrow(() -> {
-            manipulator = new XGSManipulator(Paths.get(TARGET_DIR, "weapons.xgs").toString());
+            manipulator = new XGSManipulator(Paths.get(TARGET_DIR, "weapons.xgs"));
 
-            var exeManipulator = new EXEManipulator(Paths.get(TARGET_DIR, "xops0975t.exe").toString());
+            var exeManipulator = new EXEManipulator(Paths.get(TARGET_DIR, "xops0975t.exe"));
             expectedWeapons = exeManipulator.getWeapons();
         });
     }
@@ -54,12 +55,12 @@ public class XGSManipulatorTest {
 
     @Test
     public void saveAsXGS() {
-        var srcFilepath = Paths.get(TARGET_DIR, "weapons.xgs").toString();
-        var outputFilepath = Paths.get(TARGET_DIR, "weapons_2.xgs").toString();
-        assertDoesNotThrow(() -> manipulator.saveAsXGS(outputFilepath));
+        Path srcPath = Paths.get(TARGET_DIR, "weapons.xgs");
+        Path outputPath = Paths.get(TARGET_DIR, "weapons_2.xgs");
+        assertDoesNotThrow(() -> manipulator.save(outputPath));
 
-        String srcFileHash = TestUtils.getFileHash(srcFilepath);
-        String outputFileHash = TestUtils.getFileHash(outputFilepath);
+        String srcFileHash = TestUtils.getFileHash(srcPath);
+        String outputFileHash = TestUtils.getFileHash(outputPath);
         assertEquals(srcFileHash, outputFileHash);
     }
 }


### PR DESCRIPTION
# Overview

New implementation uses only `Path` for read and write of files.
Methods that take `OutputStream`, `File`, and  `String` are removed to simplify code maintenance.
